### PR TITLE
Standardize form styling across user-facing forms and clean `our-palette.css`

### DIFF
--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -274,7 +274,7 @@
 
 
 
-@keyframes pulse {
+@keyframes pulse-highlight {
     0% {
         box-shadow: 0 0 0 0 rgba(255, 193, 7, 0.7);
     }
@@ -723,22 +723,6 @@
    Account & Preferences (Portal)
    Targets classes used in portal-account section
    ========================== */
-
-#portal-account .form-input {
-  border-radius: 14px !important;
-  border: 1px solid rgba(17, 24, 39, 0.12) !important;
-  background: rgba(255, 255, 255, 0.98) !important;
-  padding: 12px 14px !important;
-  font-family: "Alata", sans-serif !important;
-  font-size: 0.95rem !important;
-  transition: all 0.18s ease !important;
-}
-
-#portal-account .form-input:focus {
-  border-color: rgba(22, 119, 255, 0.65) !important;
-  box-shadow: 0 0 0 4px rgba(22, 119, 255, 0.12) !important;
-  background: #ffffff !important;
-}
 
 /* Header row */
 .account-header {
@@ -1563,7 +1547,7 @@
 
 
 .feature-highlight {
-    animation: pulse 1.5s infinite;
+    animation: pulse-highlight 1.5s infinite;
     border-radius: 8px;
 }
 
@@ -1584,7 +1568,7 @@
     text-transform: uppercase;
 
     box-shadow: 0 2px 5px rgba(238, 90, 111, 0.4);
-    animation: pulse 2s infinite;
+    animation: pulse-badge 2s infinite;
 
     margin-left: 6px;
 
@@ -1593,7 +1577,7 @@
 }
 
 
-@keyframes pulse {
+@keyframes pulse-badge {
     0% {
         box-shadow: 0 2px 5px rgba(238, 90, 111, 0.5);
     }
@@ -1920,11 +1904,20 @@
 }
 
 .form-input {
-    /* border-radius: 5rem; */
-    border: 1px solid var(--primary-color) !important;
-    padding: 8px;
-    /* margin-bottom: 10px; */
+    border-radius: 14px !important;
+    border: 1px solid rgba(0, 0, 0, 0.10) !important;
+    background: rgba(0, 0, 0, 0.015) !important;
+    color: var(--text-cleanar-color) !important;
+    box-shadow: none !important;
+    padding: 12px 14px !important;
     width: 100%;
+    transition: border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.form-input:focus {
+    border-color: rgba(13, 110, 253, 0.55) !important;
+    box-shadow: 0 0 0 4px rgba(13, 110, 253, 0.12) !important;
+    background: #fff !important;
 }
 
 .service-selection,

--- a/client/src/components/Pages/Landing/ContactUs.jsx
+++ b/client/src/components/Pages/Landing/ContactUs.jsx
@@ -62,7 +62,7 @@ const ContactUs = () => {
   return (
     <section className="py-5">
       <Card
-        className="shadow-lg mx-auto rounded-4 bg-transparent"
+        className="cleanar-card shadow-lg mx-auto rounded-4 bg-transparent"
         style={{ maxWidth: 980 }}
       >
         <div className="p-3 p-md-5">
@@ -84,14 +84,14 @@ const ContactUs = () => {
             <Row className="g-3">
               <Col xs={12} md={6}>
                 <Form.Group controlId="name">
-                  <Form.Label>{t("contact.form.name_label")}</Form.Label>
+                  <Form.Label className="cleanarLabel">{t("contact.form.name_label")}</Form.Label>
                   <Form.Control
                     type="text"
                     name="name"
                     value={formData.name}
                     onChange={handleChange}
                     placeholder={t("contact.form.name_placeholder")}
-                    className="text-cleanar-color form-input"
+                    className="text-cleanar-color form-input cleanarInput"
                     required
                   />
                 </Form.Group>
@@ -99,14 +99,14 @@ const ContactUs = () => {
 
               <Col xs={12} md={6}>
                 <Form.Group controlId="email">
-                  <Form.Label>{t("contact.form.email_label")}</Form.Label>
+                  <Form.Label className="cleanarLabel">{t("contact.form.email_label")}</Form.Label>
                   <Form.Control
                     type="email"
                     name="email"
                     value={formData.email}
                     onChange={handleChange}
                     placeholder={t("contact.form.email_placeholder")}
-                    className="text-cleanar-color form-input"
+                    className="text-cleanar-color form-input cleanarInput"
                     required
                   />
                 </Form.Group>
@@ -114,28 +114,28 @@ const ContactUs = () => {
 
               <Col xs={12} md={6}>
                 <Form.Group controlId="phone">
-                  <Form.Label>{t("contact.form.phone_label")}</Form.Label>
+                  <Form.Label className="cleanarLabel">{t("contact.form.phone_label")}</Form.Label>
                   <Form.Control
                     type="tel"
                     name="phone"
                     value={formData.phone}
                     onChange={handleChange}
                     placeholder={t("contact.form.phone_placeholder")}
-                    className="text-cleanar-color form-input"
+                    className="text-cleanar-color form-input cleanarInput"
                   />
                 </Form.Group>
               </Col>
 
               <Col xs={12} md={6}>
                 <Form.Group controlId="subject">
-                  <Form.Label>{t("contact.form.subject_label")}</Form.Label>
+                  <Form.Label className="cleanarLabel">{t("contact.form.subject_label")}</Form.Label>
                   <Form.Control
                     type="text"
                     name="subject"
                     value={formData.subject}
                     onChange={handleChange}
                     placeholder={t("contact.form.subject_placeholder")}
-                    className="text-cleanar-color form-input"
+                    className="text-cleanar-color form-input cleanarInput"
                     required
                   />
                 </Form.Group>
@@ -143,7 +143,7 @@ const ContactUs = () => {
 
               <Col xs={12}>
                 <Form.Group controlId="message">
-                  <Form.Label>{t("contact.form.message_label")}</Form.Label>
+                  <Form.Label className="cleanarLabel">{t("contact.form.message_label")}</Form.Label>
                   <Form.Control
                     as="textarea"
                     name="message"
@@ -151,7 +151,7 @@ const ContactUs = () => {
                     onChange={handleChange}
                     rows={5}
                     placeholder={t("contact.form.message_placeholder")}
-                    className="text-cleanar-color form-input"
+                    className="text-cleanar-color form-input cleanarInput"
                     required
                   />
                 </Form.Group>
@@ -169,7 +169,7 @@ const ContactUs = () => {
                     variant="primary"
                     type="submit"
                     disabled={status.loading}
-                    className="px-4"
+                    className="px-4 cleanar-hero-cta__primary"
                     style={{ minWidth: 180 }}
                   >
                     {status.loading

--- a/client/src/components/Pages/UserJourney/LoginPage.jsx
+++ b/client/src/components/Pages/UserJourney/LoginPage.jsx
@@ -259,13 +259,14 @@ function LoginPage({ focus }) {
     <>
       <VisitorCounter page={"login-page"} />
       <div
-        className=" bg-light "
+        className="cleanar-app-bg py-4 py-md-5"
       // style={{ backgroundImage: `url(${pageBg})`, backgroundSize: "cover" }}
       >
         {/* <h1 className="title primary-color text-center montserrat-bold">
           {t("login.title")}
         </h1> */}
         <Container className="container">
+          <div className="cleanar-card p-3 p-md-4 mx-auto" style={{ maxWidth: 720 }}>
           {/* <p className="text-cleanar-color text-bold text-center">
             {t("login.description")}
           </p> */}
@@ -279,7 +280,7 @@ function LoginPage({ focus }) {
             <Row className="justify-content-center">
               <Col className="py-1" md="12" xs="12">
                 <Form.Group controlId="loginEmail">
-                  <Form.Label className="text-cleanar-color">
+                  <Form.Label className="cleanarLabel text-cleanar-color">
                     {t("login.email_label")} {' '}
                     <FaQuestionCircle
                       onClick={() => togglePopover("email")}
@@ -299,7 +300,7 @@ function LoginPage({ focus }) {
 
                   <Form.Control
                     type="email"
-                    className="form-input rounded-pill text-cleanar-color"
+                    className="form-input cleanarInput text-cleanar-color"
                     placeholder=""
                     ref={emailRef}
                     name="email"
@@ -344,7 +345,7 @@ function LoginPage({ focus }) {
             <Row className="justify-content-center">
               <Col className="py-1" md="12" xs="12">
                 <Form.Group controlId="loginPassword">
-                  <Form.Label className="text-cleanar-color">
+                  <Form.Label className="cleanarLabel text-cleanar-color">
                     {t("login.password_label")} {' '}
                     <FaQuestionCircle
                       id="Tooltip2"
@@ -365,7 +366,7 @@ function LoginPage({ focus }) {
                       type={showPassword ? "text" : "password"}
                       placeholder=""
                       ref={passwordRef}
-                      className="form-input rounded-pill text-cleanar-color pe-5"
+                      className="form-input cleanarInput text-cleanar-color pe-5"
                       name="password"
                       value={formData.password}
                       onChange={handleChange}
@@ -434,7 +435,7 @@ function LoginPage({ focus }) {
             <Row className="justify-content-center mt-3">
               <Col className="py-1" md="12" xs="12">
                 <Button
-                  className="btn  primary-bg-color"
+                  className="btn primary-bg-color cleanar-hero-cta__primary"
                   type="submit"
                   data-track="login"
                   // size="lg"
@@ -488,6 +489,7 @@ function LoginPage({ focus }) {
 </Row> */}
 
           </Form>
+          </div>
         </Container>
       </div>
     </>

--- a/client/src/components/Pages/UserJourney/QuoteRequest_v2.jsx
+++ b/client/src/components/Pages/UserJourney/QuoteRequest_v2.jsx
@@ -474,7 +474,7 @@ const QuoteRequest = () => {
                         type="select"
                         name={opt.key}
                         aria-label={t(opt.labelKey)}
-                        className="text-cleanar-color form-input"
+                        className="text-cleanar-color form-input cleanarInput"
                         value={customOptions[opt.key]?.service || ''}
                         onChange={handleCustomOptionChange}
                     >
@@ -497,7 +497,7 @@ const QuoteRequest = () => {
                                     type="radio"
                                     name={opt.key}
                                     aria-label={t(opt.labelKey)}
-                                    className="text-cleanar-color form-input"
+                                    className="text-cleanar-color form-input cleanarInput"
                                     value={c.value}
                                     checked={customOptions[opt.key]?.service === c.value}
                                     onChange={handleCustomOptionChange}
@@ -519,7 +519,7 @@ const QuoteRequest = () => {
                             name={opt.key}
                             aria-label={t(opt.labelKey)}
                             // size="sm"
-                            className="text-cleanar-color form-input"
+                            className="text-cleanar-color form-input cleanarInput"
                             value={customOptions[opt.key]?.service || ''}
                             onChange={handleCustomOptionChange}
                             min={new Date().toISOString().split('T')[0]}
@@ -553,7 +553,7 @@ const QuoteRequest = () => {
                 name={opt.key}
                 aria-label={t(opt.labelKey)}
                 value={customOptions[opt.key]?.service || ''}
-                className="text-cleanar-color form-input"
+                className="text-cleanar-color form-input cleanarInput"
                 onChange={handleCustomOptionChange}
                 placeholder={opt.unitKey || ''}
             />
@@ -621,7 +621,7 @@ const QuoteRequest = () => {
                                 { label: t('quick_quote.form.promoCode'), name: 'promoCode', placeholder: 'Promo123' }
                             ].map(({ label, name, placeholder, required }) => (
                                 <Col key={name} md={3} xs={6} className="mb-2 ">
-                                    <Form.Label className="text-bold mb-1">
+                                    <Form.Label className="cleanarLabel mb-1">
                                         {label}{required && '*'}
                                         <FaQuestionCircle
                                             id={`${name}Tooltip`}
@@ -642,7 +642,7 @@ const QuoteRequest = () => {
                                         id={`floating${label.replace(' ', '')}`}
                                         placeholder={placeholder}
                                         aria-label={label}
-                                        className="text-cleanar-color form-input rounded-pill"
+                                        className="text-cleanar-color form-input cleanarInput"
                                         name={name}
                                         value={formData[name]}
                                         onChange={handleChange}


### PR DESCRIPTION
### Motivation
- Provide a consistent, modern look-and-feel for site forms by reusing the existing design tokens and classes in `our-palette.css` so forms across pages feel the same. 
- Reduce CSS duplication and avoid conflicting animations to make the palette file easier to maintain and reason about. 

### Description
- Applied palette classes to unify form UI: updated `LoginPage.jsx` to use `cleanar-app-bg`, wrapped the form in a `cleanar-card`, and switched inputs/labels/buttons to `cleanarInput`, `cleanarLabel`, and `cleanar-hero-cta__primary`. 
- Applied the same input/label/button standardization to `ContactUs.jsx` by adding `cleanar-card`, `cleanarLabel`, `cleanarInput`, and consistent CTA styling. 
- Normalized Quick Quote form controls in `QuoteRequest_v2.jsx` by adding `cleanarInput` and `cleanarLabel` to dynamic and top-level fields. 
- Cleaned `client/src/assets/css/our-palette.css` by consolidating duplicate `#portal-account .form-input` definitions, introducing a canonical `.form-input` base with consistent focus state, and resolving animation name conflicts by splitting `pulse` into `pulse-highlight` and `pulse-badge`. 
- No submission or business-logic changes were made; all edits are presentational/CSS and class-name adjustments. 

### Testing
- Ran a production build with `npm --prefix client run build` which completed successfully. 
- No automated test suites were modified or executed beyond the build step, and the build produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d846c9a2b8832988c6104f93712d3f)