### PR TITLE
Prerender marketing routes and neutralize base index.html SEO defaults

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -13,23 +13,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description"
-    content="CleanAR Solutions offers cleaning services in Toronto and the GTA. Book your local cleaner today for reliable, eco-friendly cleaning solutions!" />
+    content="CleanAR Solutions provides professional cleaning services across Toronto and the GTA for homes and businesses." />
   <meta name="keywords"
     content="cleaning, professional cleaning, residential cleaning, commercial cleaning, CleanAR Solutions, GTA, Toronto, carpet cleaning, upholstery cleaning, local cleaners" />
   <meta name="author" content="CleanAR Solutions" />
   <!-- Google / Search Engine Tags -->
   <meta itemprop="name" content="CleanAR Solutions" />
   <meta itemprop="description"
-    content="CleanAR Solutions offers top-quality cleaning services across Toronto and the GTA. From deep clean, regular maintenance, to specialized property cleanouts, we tailor our services to serve your needs." />
+    content="CleanAR Solutions provides professional cleaning services across Toronto and the GTA for homes and businesses." />
   <meta itemprop="image" content="https://www.cleanarsolutions.ca/og-image.jpg" />
-      <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.cleanarsolutions.ca/" />
-    <meta property="og:title" content="CleanAR Solutions - Professional Cleaning Services" />
-    <meta property="og:description" content="Expert cleaning services in Toronto & GTA. Book your professional cleaning service today and enjoy a spotless environment!" />
-    <meta property="og:image" content="https://www.cleanarsolutions.ca/og-image.jpg" />
-    <meta property="og:image:alt" content="CleanAR Solutions Professional Cleaning Services" />
-    <meta property="og:site_name" content="CleanAR Solutions" />
-    <meta property="og:locale" content="en_CA" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://www.cleanarsolutions.ca/" />
+  <meta property="og:title" content="CleanAR Solutions | Professional Cleaning Services" />
+  <meta property="og:description"
+    content="CleanAR Solutions provides professional cleaning services across Toronto and the GTA for homes and businesses." />
+  <meta property="og:image" content="https://www.cleanarsolutions.ca/og-image.jpg" />
+  <meta property="og:image:alt" content="CleanAR Solutions Professional Cleaning Services" />
+  <meta property="og:site_name" content="CleanAR Solutions" />
+  <meta property="og:locale" content="en_CA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CleanAR Solutions | Professional Cleaning Services" />
+  <meta name="twitter:description"
+    content="CleanAR Solutions provides professional cleaning services across Toronto and the GTA for homes and businesses." />
+  <meta name="twitter:image" content="https://www.cleanarsolutions.ca/og-image.jpg" />
+  <link rel="canonical" href="https://www.cleanarsolutions.ca/" />
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -62,7 +69,7 @@
   <noscript>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.1/css/all.css" />
   </noscript>
-  <title>CleanAR Solutions</title>
+  <title>CleanAR Solutions | Professional Cleaning Services</title>
   <!-- Google tag (gtag.js) -->
   <!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-PTN1K0J7Q8"></script>
   <script>
@@ -122,16 +129,8 @@
 <body>
   <script type="module" src="/src/index.jsx"></script>
   <noscript>
-    <h1>Welcome to CleanAR Solutions</h1>
-    <h2>
-      At CleanAR Solutions, we offers top-quality cleaning services across Toronto and the GTA. From deep clean, regular
-      maintenance, to specialized property cleanouts, we tailor our services to serve your needs.
-      Our team of experienced professionals is dedicated to providing you with the best cleaning experience possible. We
-      use eco-friendly products and advanced techniques to ensure your space is spotless and safe for you and your
-      family.
-      Whether you need a one-time deep clean or regular maintenance, we have the right solution for you. Our services
-      include residential cleaning, commercial cleaning, carpet cleaning, upholstery cleaning, and more.
-    </h2>
+    <h1>CleanAR Solutions</h1>
+    <h2>Professional cleaning services for homes and businesses in Toronto and the GTA.</h2>
   </noscript>
   <div id="root"></div>
   <!--

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node ./scripts/prerender-marketing-routes.mjs",
     "preview": "vite preview",
     "start": "vite",
     "media:bootstrap": "bash ./scripts/bootstrap-media-tooling.sh",

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -21,6 +21,31 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.cleanarsolutions.ca/services/residential-cleaning</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/services/commercial-cleaning</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/services/window-cleaning</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/services/carpet-and-upholstery-cleaning</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/services/power-pressure-washing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://www.cleanarsolutions.ca/blog/cleanar-solutions-joins-issa-canada</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/client/scripts/prerender-marketing-routes.mjs
+++ b/client/scripts/prerender-marketing-routes.mjs
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const BASE_URL = "https://www.cleanarsolutions.ca";
+const DIST_DIR = path.resolve(process.cwd(), "dist");
+const DIST_INDEX = path.join(DIST_DIR, "index.html");
+const OG_IMAGE = `${BASE_URL}/og-image.jpg`;
+
+const ROUTES = [
+  {
+    route: "/",
+    output: "index.html",
+    title: "CleanAR Solutions - Professional Cleaning Services in Toronto & GTA",
+    description:
+      "Professional cleaning services in Toronto & GTA. Residential, commercial, carpet & upholstery cleaning. Get your free quote today!",
+    canonical: `${BASE_URL}/`,
+    h1: "Professional Cleaning Services in Toronto & GTA",
+  },
+  {
+    route: "/index",
+    output: "index/index.html",
+    title: "CleanAR Solutions - Professional Cleaning Services in Toronto & GTA",
+    description:
+      "Professional cleaning services in Toronto & GTA. Residential, commercial, carpet & upholstery cleaning. Get your free quote today!",
+    canonical: `${BASE_URL}/index`,
+    h1: "Book Trusted Cleaning Services with CleanAR Solutions",
+  },
+  {
+    route: "/about-us",
+    output: "about-us/index.html",
+    title: "About CleanAR Solutions | Toronto & GTA Cleaning Team",
+    description:
+      "Learn about CleanAR Solutions, our mission, and our commitment to reliable, high-quality cleaning services across Toronto and the GTA.",
+    canonical: `${BASE_URL}/about-us`,
+    h1: "About Our Toronto Cleaning Team",
+  },
+  {
+    route: "/products-and-services",
+    output: "products-and-services/index.html",
+    title: "Cleaning Services | Residential & Commercial | CleanAR Solutions",
+    description:
+      "Explore residential and commercial cleaning services from CleanAR Solutions in Toronto and the GTA.",
+    canonical: `${BASE_URL}/products-and-services`,
+    h1: "Residential and Commercial Cleaning Services",
+  },
+  {
+    route: "/blog",
+    output: "blog/index.html",
+    title: "CleanAR Blog | Cleaning Insights & Company Updates",
+    description:
+      "Read the latest news, certifications, and cleaning insights from CleanAR Solutions.",
+    canonical: `${BASE_URL}/blog`,
+    h1: "CleanAR Blog and Company Updates",
+  },
+  {
+    route: "/services/residential-cleaning",
+    output: "services/residential-cleaning/index.html",
+    title: "Residential Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Recurring and one-time residential cleaning services in Toronto and the GTA from the CleanAR Solutions team.",
+    canonical: `${BASE_URL}/services/residential-cleaning`,
+    h1: "Residential Cleaning Services",
+  },
+  {
+    route: "/services/commercial-cleaning",
+    output: "services/commercial-cleaning/index.html",
+    title: "Commercial Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Professional commercial cleaning for offices and facilities in Toronto and the GTA by CleanAR Solutions.",
+    canonical: `${BASE_URL}/services/commercial-cleaning`,
+    h1: "Commercial Cleaning Services",
+  },
+  {
+    route: "/services/window-cleaning",
+    output: "services/window-cleaning/index.html",
+    title: "Window Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Interior and exterior window cleaning services for homes and businesses across Toronto and the GTA.",
+    canonical: `${BASE_URL}/services/window-cleaning`,
+    h1: "Window Cleaning Services",
+  },
+  {
+    route: "/services/carpet-and-upholstery-cleaning",
+    output: "services/carpet-and-upholstery-cleaning/index.html",
+    title: "Carpet & Upholstery Cleaning in Toronto | CleanAR Solutions",
+    description:
+      "Deep carpet and upholstery cleaning services to refresh homes and workplaces in Toronto and surrounding GTA areas.",
+    canonical: `${BASE_URL}/services/carpet-and-upholstery-cleaning`,
+    h1: "Carpet and Upholstery Cleaning Services",
+  },
+  {
+    route: "/services/power-pressure-washing",
+    output: "services/power-pressure-washing/index.html",
+    title: "Power & Pressure Washing in Toronto | CleanAR Solutions",
+    description:
+      "Power and pressure washing services for exterior surfaces throughout Toronto and the GTA.",
+    canonical: `${BASE_URL}/services/power-pressure-washing`,
+    h1: "Power and Pressure Washing Services",
+  },
+];
+
+const upsertTag = (html, pattern, replacement) => {
+  if (pattern.test(html)) {
+    return html.replace(pattern, replacement);
+  }
+  return html.replace("</head>", `  ${replacement}\n</head>`);
+};
+
+const buildRouteHtml = (baseHtml, routeMeta) => {
+  let html = baseHtml;
+
+  html = html.replace(/<title>.*?<\/title>/is, `<title>${routeMeta.title}</title>`);
+  html = upsertTag(
+    html,
+    /<meta\s+name=["']description["'][^>]*>/i,
+    `<meta name="description" content="${routeMeta.description}" />`
+  );
+  html = upsertTag(
+    html,
+    /<link\s+rel=["']canonical["'][^>]*>/i,
+    `<link rel="canonical" href="${routeMeta.canonical}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+property=["']og:url["'][^>]*>/i,
+    `<meta property="og:url" content="${routeMeta.canonical}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+property=["']og:title["'][^>]*>/i,
+    `<meta property="og:title" content="${routeMeta.title}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+property=["']og:description["'][^>]*>/i,
+    `<meta property="og:description" content="${routeMeta.description}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+property=["']og:image["'][^>]*>/i,
+    `<meta property="og:image" content="${OG_IMAGE}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+name=["']twitter:card["'][^>]*>/i,
+    '<meta name="twitter:card" content="summary_large_image" />'
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+name=["']twitter:title["'][^>]*>/i,
+    `<meta name="twitter:title" content="${routeMeta.title}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+name=["']twitter:description["'][^>]*>/i,
+    `<meta name="twitter:description" content="${routeMeta.description}" />`
+  );
+  html = upsertTag(
+    html,
+    /<meta\s+name=["']twitter:image["'][^>]*>/i,
+    `<meta name="twitter:image" content="${OG_IMAGE}" />`
+  );
+
+  const bodyNoscriptPattern = /(<body[^>]*>\s*)(<noscript>[\s\S]*?<\/noscript>)/i;
+  const noscriptContent = `<noscript>\n    <h1>${routeMeta.h1}</h1>\n    <h2>${routeMeta.description}</h2>\n  </noscript>`;
+  html = html.replace(bodyNoscriptPattern, `$1${noscriptContent}`);
+
+  return html;
+};
+
+if (!fs.existsSync(DIST_INDEX)) {
+  throw new Error(`Cannot prerender routes because ${DIST_INDEX} was not found.`);
+}
+
+const baseHtml = fs.readFileSync(DIST_INDEX, "utf8");
+
+for (const route of ROUTES) {
+  const routeHtml = buildRouteHtml(baseHtml, route);
+  const outputPath = path.join(DIST_DIR, route.output);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, routeHtml, "utf8");
+}
+
+const generatedPaths = ROUTES.map((route) => route.output).join(", ");
+console.log(`Generated prerendered marketing routes: ${generatedPaths}`);

--- a/client/scripts/prerender-marketing-routes.mjs
+++ b/client/scripts/prerender-marketing-routes.mjs
@@ -161,7 +161,7 @@ const buildRouteHtml = (baseHtml, routeMeta) => {
     `<meta name="twitter:image" content="${OG_IMAGE}" />`
   );
 
-  const bodyNoscriptPattern = /(<body[^>]*>\s*)(<noscript>[\s\S]*?<\/noscript>)/i;
+  const bodyNoscriptPattern = /(<body[^>]*>[\s\S]*?)(<noscript>[\s\S]*?<\/noscript>)/i;
   const noscriptContent = `<noscript>\n    <h1>${routeMeta.h1}</h1>\n    <h2>${routeMeta.description}</h2>\n  </noscript>`;
   html = html.replace(bodyNoscriptPattern, `$1${noscriptContent}`);
 

--- a/client/src/components/Pages/Management/MetaTags.jsx
+++ b/client/src/components/Pages/Management/MetaTags.jsx
@@ -37,6 +37,31 @@ const ROUTE_META = {
     description:
       "Read the latest news, certifications, and cleaning insights from CleanAR Solutions.",
   },
+  "/services/residential-cleaning": {
+    title: "Residential Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Recurring and one-time residential cleaning services in Toronto and the GTA from the CleanAR Solutions team.",
+  },
+  "/services/commercial-cleaning": {
+    title: "Commercial Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Professional commercial cleaning for offices and facilities in Toronto and the GTA by CleanAR Solutions.",
+  },
+  "/services/window-cleaning": {
+    title: "Window Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Interior and exterior window cleaning services for homes and businesses across Toronto and the GTA.",
+  },
+  "/services/carpet-and-upholstery-cleaning": {
+    title: "Carpet & Upholstery Cleaning in Toronto | CleanAR Solutions",
+    description:
+      "Deep carpet and upholstery cleaning services to refresh homes and workplaces in Toronto and surrounding GTA areas.",
+  },
+  "/services/power-pressure-washing": {
+    title: "Power & Pressure Washing in Toronto | CleanAR Solutions",
+    description:
+      "Power and pressure washing services for exterior surfaces throughout Toronto and the GTA.",
+  },
   "/blog/cleanar-solutions-joins-issa-canada": {
     title: "CleanAR Solutions Joins ISSA Canada | CleanAR Blog",
     description:

--- a/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
+++ b/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+
+const SERVICE_CONTENT = {
+  "residential-cleaning": {
+    title: "Residential Cleaning Services",
+    intro:
+      "Keep your home consistently clean with recurring or one-time residential cleaning delivered by the CleanAR Solutions team.",
+    query: "Residential+Cleaning",
+  },
+  "commercial-cleaning": {
+    title: "Commercial Cleaning Services",
+    intro:
+      "Maintain a healthier, more professional workplace with customized commercial cleaning services for offices and facilities.",
+    query: "Commercial+Cleaning",
+  },
+  "window-cleaning": {
+    title: "Window Cleaning Services",
+    intro:
+      "Improve curb appeal and indoor light with interior and exterior window cleaning for homes and businesses.",
+    query: "Window+Cleaning",
+  },
+  "carpet-and-upholstery-cleaning": {
+    title: "Carpet and Upholstery Cleaning Services",
+    intro:
+      "Refresh carpets and soft surfaces with deep cleaning solutions that remove built-up soil, odors, and stains.",
+    query: "Carpet+And+Upholstery",
+  },
+  "power-pressure-washing": {
+    title: "Power and Pressure Washing Services",
+    intro:
+      "Restore outdoor surfaces with targeted pressure washing for walkways, entries, and exterior areas.",
+    query: "Power/Pressure+Washing",
+  },
+};
+
+const ServiceLandingPage = () => {
+  const { serviceSlug } = useParams();
+  const service = useMemo(() => SERVICE_CONTENT[serviceSlug], [serviceSlug]);
+
+  if (!service) {
+    return <Navigate to="/products-and-services" replace />;
+  }
+
+  return (
+    <section className="container py-5 mt-5">
+      <h1 className="primary-color text-bold mb-3">{service.title}</h1>
+      <p className="lead text-cleanar-color mb-4">{service.intro}</p>
+      <div className="d-flex flex-wrap gap-2">
+        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/index?service=${service.query}`}>
+          Request a Quote
+        </Link>
+        <Link className="btn btn-outline-secondary btn-round" to="/products-and-services">
+          View All Services
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default ServiceLandingPage;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -26,6 +26,7 @@ const LoginSign = lazy(() => import("/src/components/Pages/UserJourney/LoginSign
 const SignUp = lazy(() => import("/src/components/Pages/UserJourney/SignUp"));
 const ProductsAndServices = lazy(() => import("/src/components/Pages/Navigation/ProductsAndServices"));
 const Career = lazy(() => import("/src/components/Pages/Navigation/Career.jsx"));
+const ServiceLandingPage = lazy(() => import("/src/components/Pages/Navigation/ServiceLandingPage.jsx"));
 const ResetPassword = lazy(() => import("/src/components/Pages/UserJourney/ResetPassword"));
 const BlogLandingPage = lazy(() => import("/src/components/Pages/Blogs/BlogLandingPage.jsx"));
 const CleanARJoinsISSACanada = lazy(() => import("/src/components/Pages/Blogs/CleanARJoinsISSACanada"));
@@ -174,6 +175,7 @@ const App = () => {
               <Route path="/careers" element={<Career />} />
               <Route path="/about-us" element={<AboutUsPage />} />
               <Route path="/products-and-services" element={<ProductsAndServices />} />
+              <Route path="/services/:serviceSlug" element={<ServiceLandingPage />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/terms-conditions" element={<Terms />} />
               <Route path="/disclaimer" element={<Disclaimer />} />


### PR DESCRIPTION
### Motivation
- Prevent the client shell (`index.html`) from exposing homepage-specific marketing copy before hydration by replacing homepage-biased metadata and noscript text with neutral, brand-level fallbacks.
- Provide crawlers with route-aware HTML so marketing and service pages are indexed with the correct title/description/OG data before JavaScript runs.
- Ensure each prerendered route contains a unique H1 and full metadata so search engines and social previews are accurate for core marketing routes.

### Description
- Replaced homepage-specific copy in `client/index.html` with neutral brand-level metadata and added canonical + Twitter defaults and a concise noscript H1/H2 fallback.
- Added `client/scripts/prerender-marketing-routes.mjs`, a Node script that reads `dist/index.html` and writes route-specific HTML files (titles, description, canonical, OG/Twitter tags and noscript H1) for core marketing routes and key service pages.
- Included these routes: `/`, `/index`, `/about-us`, `/products-and-services`, `/blog`, and service pages under `/services/*` (residential, commercial, window, carpet & upholstery, power/pressure washing).
- Wired prerender generation into the frontend build by changing `client/package.json` `build` to run the prerender script after `vite build`.

### Testing
- Ran `npm run build` in `client/`; the `vite build` completed and the prerender script executed without errors.
- Confirmed generated files in `client/dist/` (e.g. `about-us/index.html`, `products-and-services/index.html`, `services/residential-cleaning/index.html`) contain route-specific `<title>`, description, canonical, OG/Twitter tags and unique noscript `<h1>` content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deeb5834b0832996284ed94209a060)