### PR TITLE
Canonicalize homepage to / and keep /index compatibility route

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.cleanarsolutions.ca/index</loc>
+    <loc>https://www.cleanarsolutions.ca/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/client/src/components/Pages/Blogs/BlogLandingPage.jsx
+++ b/client/src/components/Pages/Blogs/BlogLandingPage.jsx
@@ -35,7 +35,7 @@ function BlogLandingPage() {
   const [activeCategory, setActiveCategory] = useState("All");
   const [sortBy, setSortBy] = useState("newest"); // newest | a-z
 
-  const goToQuote = () => navigate("/index?scrollToQuote=true");
+  const goToQuote = () => navigate("/?scrollToQuote=true");
 
   useEffect(() => {
     document.body.classList.add("index-page", "sidebar-collapse");

--- a/client/src/components/Pages/Certifications/CertificationsMembershipsPage.jsx
+++ b/client/src/components/Pages/Certifications/CertificationsMembershipsPage.jsx
@@ -24,7 +24,7 @@ function CertificationsMembershipsPage() {
   const navigate = useNavigate();
 
   const goToQuote = () => {
-    navigate("/index?scrollToQuote=true");
+    navigate("/?scrollToQuote=true");
   };
 
   useEffect(() => {

--- a/client/src/components/Pages/Management/MetaTags.jsx
+++ b/client/src/components/Pages/Management/MetaTags.jsx
@@ -35,7 +35,10 @@ const MetaTags = () => {
   const normalizedPathname = normalizePathname(pathname);
 
   const routeMeta = ROUTE_META[normalizedPathname] ?? defaultMeta;
-  const canonicalPath = normalizePathname(routeMeta.canonicalPath ?? normalizedPathname);
+  const canonicalPath =
+    normalizedPathname === "/index"
+      ? "/"
+      : normalizePathname(routeMeta.canonicalPath ?? normalizedPathname);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const pageUrl = `${BASE_URL}${normalizedPathname}`;
   const noindex = NOINDEX_PATTERNS.some((pattern) => pattern.test(normalizedPathname));

--- a/client/src/components/Pages/Navigation/AboutUs.jsx
+++ b/client/src/components/Pages/Navigation/AboutUs.jsx
@@ -32,7 +32,7 @@ function AboutUsPage() {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?scrollToQuote=true');
+    navigate('/?scrollToQuote=true');
   };
 
   useEffect(() => {

--- a/client/src/components/Pages/Navigation/Navbar.jsx
+++ b/client/src/components/Pages/Navigation/Navbar.jsx
@@ -205,7 +205,7 @@ function IndexNavbar() {
             <Navbar className={`mb-0 ${navbarColor}`} expand="md" role="navigation">
                 <Container fluid className="nav-shell">
                     {/* LEFT: Brand */}
-                    <NavbarBrand href="/index" className="brand" onClick={handleNavClick}>
+                    <NavbarBrand href="/" className="brand" onClick={handleNavClick}>
                         {/* <img src={logo} alt="CleanAR Solutions" className="navbarlogo" /> */}
                         <picture>
                             <source srcSet={logoAvif} type="image/avif" />
@@ -281,7 +281,7 @@ function IndexNavbar() {
                                         <DropdownItem href="/profile-page">{t("navbar.profile")}</DropdownItem>
                                         <DropdownItem divider />
                                         <DropdownItem
-                                            href="/index"
+                                            href="/"
                                             onClick={(e) => {
                                                 // e.preventDefault();
                                                 Auth.logout();

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -99,7 +99,7 @@ const ProductsAndServices = () => {
       width: 5906,
       height: 3937,
       description: t("products_and_services.residential_cleaning_description", { returnObjects: true }),
-      quoteLink: "/index?service=Residential+Cleaning",
+      quoteLink: "/?service=Residential+Cleaning",
       quoteButtonText: t("products_and_services.residential_cleaning_button")
     },
     {
@@ -111,7 +111,7 @@ const ProductsAndServices = () => {
       width: 4536,
       height: 3024,
       description: t("products_and_services.commercial_cleaning_description", { returnObjects: true }),
-      quoteLink: "/index?service=Commercial+Cleaning",
+      quoteLink: "/?service=Commercial+Cleaning",
       quoteButtonText: t("products_and_services.commercial_cleaning_button")
     },
     {
@@ -123,7 +123,7 @@ const ProductsAndServices = () => {
       width: 1024,
       height: 683,
       description: t("products_and_services.window_cleaning_description", { returnObjects: true }),
-      quoteLink: "/index?service=Window+Cleaning",
+      quoteLink: "/?service=Window+Cleaning",
       quoteButtonText: t("products_and_services.window_cleaning_button")
     },
     {
@@ -135,7 +135,7 @@ const ProductsAndServices = () => {
       width: 1024,
       height: 683,
       description: t("products_and_services.carpet_cleaning_description", { returnObjects: true }),
-      quoteLink: "/index?service=Carpet+And+Upholstery",
+      quoteLink: "/?service=Carpet+And+Upholstery",
       quoteButtonText: t("products_and_services.carpet_and_upholstery_button")
     },
     {
@@ -147,7 +147,7 @@ const ProductsAndServices = () => {
       width: 1024,
       height: 683,
       description: t("products_and_services.power_washing_description", { returnObjects: true }),
-      quoteLink: "/index?service=Power/Pressure+Washing",
+      quoteLink: "/?service=Power/Pressure+Washing",
       quoteButtonText: t("products_and_services.power_pressure_washing_button")
     }
   ];

--- a/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
+++ b/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
@@ -47,7 +47,7 @@ const ServiceLandingPage = () => {
       <h1 className="primary-color text-bold mb-3">{service.title}</h1>
       <p className="lead text-cleanar-color mb-4">{service.intro}</p>
       <div className="d-flex flex-wrap gap-2">
-        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/index?service=${service.query}`}>
+        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/?service=${service.query}`}>
           Request a Quote
         </Link>
         <Link className="btn btn-outline-secondary btn-round" to="/products-and-services">

--- a/client/src/components/Pages/UserJourney/WelcomeModal.jsx
+++ b/client/src/components/Pages/UserJourney/WelcomeModal.jsx
@@ -33,9 +33,9 @@ const WelcomeModal = () => {
 
   const handleQuoteClick = (e) => {
     // trackEvent('quote_clicked');
-    // navigate('/index?promoCode=welcome15', { state: { scrollToQuote: true } }); 
+    // navigate('/?promoCode=welcome15', { state: { scrollToQuote: true } }); 
     // localStorage.setItem('welcomeModalDismissed', 'true');
-    navigate('/index?promoCode=refresh15&scrollToQuote=true');    
+    navigate('/?promoCode=refresh15&scrollToQuote=true');    
     // refresh
     // window.location.reload();
     setShow(false);

--- a/client/src/components/Pages/qrCodes/LandingFresh.jsx
+++ b/client/src/components/Pages/qrCodes/LandingFresh.jsx
@@ -8,7 +8,7 @@ const LandingFresh = () => {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?promoCode=fresh15', { state: { scrollToQuote: true } });
+    navigate('/?promoCode=fresh15', { state: { scrollToQuote: true } });
   };
 
   return (

--- a/client/src/components/Pages/qrCodes/LandingNow.jsx
+++ b/client/src/components/Pages/qrCodes/LandingNow.jsx
@@ -8,7 +8,7 @@ const LandingNow = () => {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?promoCode=now15', { state: { scrollToQuote: true } });
+    navigate('/?promoCode=now15', { state: { scrollToQuote: true } });
   };
 
   return (

--- a/client/src/components/Pages/qrCodes/LandingSecret.jsx
+++ b/client/src/components/Pages/qrCodes/LandingSecret.jsx
@@ -9,7 +9,7 @@ const LandingSecret = () => {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?promoCode=secret15', { state: { scrollToQuote: true } });
+    navigate('/?promoCode=secret15', { state: { scrollToQuote: true } });
   };
 
   return (

--- a/client/src/components/Pages/qrCodes/LandingStart.jsx
+++ b/client/src/components/Pages/qrCodes/LandingStart.jsx
@@ -10,7 +10,7 @@ const LandingStart = () => {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?promoCode=start15', { state: { scrollToQuote: true } });
+    navigate('/?promoCode=start15', { state: { scrollToQuote: true } });
   };
 
   return (

--- a/client/src/components/Pages/qrCodes/LandingToronto.jsx
+++ b/client/src/components/Pages/qrCodes/LandingToronto.jsx
@@ -9,7 +9,7 @@ const LandingToronto = () => {
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/index?promoCode=toronto15', { state: { scrollToQuote: true } });
+    navigate('/?promoCode=toronto15', { state: { scrollToQuote: true } });
   };
 
   return (

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy, useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { BrowserRouter, Route, Routes, Navigate, useLocation } from "react-router-dom";
 import './i18n'; // Import i18n configuration
 import { registerSW } from 'virtual:pwa-register';
 
@@ -58,6 +58,12 @@ registerSW({
 });
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
+
+const IndexCompatibilityRedirect = () => {
+  const { search, hash } = useLocation();
+
+  return <Navigate to={{ pathname: "/", search, hash }} replace />;
+};
 
 const App = () => {
   // In your App.js
@@ -128,7 +134,7 @@ const App = () => {
             <Suspense fallback={<div className="py-5 text-center">Loading page…</div>}>
               <Routes>
               <Route path="/" element={<Index />} />
-              <Route path="/index" element={<Navigate to="/" replace />} />
+              <Route path="/index" element={<IndexCompatibilityRedirect />} />
               <Route path="/profile-page" element={<ProtectedRoute element={<ProfilePage />} />} />
               <Route path="/notification-management" element={<ProtectedRoute element={<NotificationAdminPage />} />} />
               {/* <Route path="/manage-categories" element={<ProtectedRoute element={<ManageCategories />} />} /> */}

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -127,7 +127,8 @@ const App = () => {
           <main className="flex-grow-1 main-content">
             <Suspense fallback={<div className="py-5 text-center">Loading page…</div>}>
               <Routes>
-              <Route path="/index" element={<Index />} />
+              <Route path="/" element={<Index />} />
+              <Route path="/index" element={<Navigate to="/" replace />} />
               <Route path="/profile-page" element={<ProtectedRoute element={<ProfilePage />} />} />
               <Route path="/notification-management" element={<ProtectedRoute element={<NotificationAdminPage />} />} />
               {/* <Route path="/manage-categories" element={<ProtectedRoute element={<ManageCategories />} />} /> */}
@@ -185,8 +186,8 @@ const App = () => {
               <Route path="/toronto" element={<LandingToronto />} />
               <Route path="/fresh" element={<LandingFresh />} />
               <Route path="/secret" element={<LandingSecret />} />
-              <Route path="/" element={<Navigate to="/index" />} />
-              <Route path="*" element={<Navigate to="/index" replace />} />
+              
+              <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </Suspense>
           </main>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -887,7 +887,7 @@
         "CleanAR Solutions"
       ],
       "contact": {
-        "website": "https://www.cleanarsolutions.ca/index",
+        "website": "https://www.cleanarsolutions.ca/",
         "phone": "+1 (437) 440-5514"
       }
     }

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -833,7 +833,7 @@
         "CleanAR Solutions"
       ],
       "contact": {
-        "website": "https://www.cleanarsolutions.ca/index",
+        "website": "https://www.cleanarsolutions.ca/",
         "phone": "+1 (437) 440-5514"
       }
     }

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -832,7 +832,7 @@
         "CleanAR Solutions"
       ],
       "contact": {
-        "website": "https://www.cleanarsolutions.ca/index",
+        "website": "https://www.cleanarsolutions.ca/",
         "phone": "+1 (437) 440-5514"
       }
     }

--- a/client/src/utils/generatePDF.jsx
+++ b/client/src/utils/generatePDF.jsx
@@ -182,7 +182,7 @@ const sendEmailWithPDF = async (formData, subject, pdfBase64, t) => {
             <p>${t("quick_quote.email.body.3")}</p>
             <p>CleanAR Solutions</p>
             <p>
-            <a href="https://www.cleanarsolutions.ca/index" target="_blank">www.cleanarsolutions.ca/index</a>
+            <a href="https://www.cleanarsolutions.ca/" target="_blank">www.cleanarsolutions.ca/</a>
             </p>
             <p>
             <a href="tel:+437-440-5514">+1 (437) 440-5514</a>


### PR DESCRIPTION
### Motivation
- Ensure the site uses the root URL (`/`) as the canonical homepage for SEO while preserving existing `/index` compatibility for older links and redirects.
- Update site metadata and internal links so crawlable references, sitemaps, and generated content point to the canonical root URL.

### Description
- Canonical metadata: update `MetaTags` so when the normalized pathname is `/index` the canonical path is set to `/` (file: `client/src/components/Pages/Management/MetaTags.jsx`).
- Routing: make `/` the primary homepage route and keep `/index` functional by redirecting it to `/` (file: `client/src/index.jsx`).
- Sitemap: update `client/public/sitemap.xml` to list `https://www.cleanarsolutions.ca/` as the primary homepage URL.
- Internal links and assets: replace active internal links and CTA targets that pointed to `/index` with `/` (including navigation, product/service CTAs, blog/landing/QR landing flows, and welcome modal), and update localized `website` entries and the PDF email template to use the root URL (files include `client/src/components/Pages/Navigation/*`, `client/src/components/Pages/qrCodes/*`, `client/src/components/Pages/Blogs/BlogLandingPage.jsx`, `client/src/components/Pages/Certifications/*`, `client/src/utils/generatePDF.jsx`, and `client/src/locales/*/translation.json`).

### Testing
- Ran the production build with `npm --prefix client run -s build` and it completed successfully (vite build finished and prerendered marketing routes were generated).
- Verified code changes with source search patterns to ensure active navigation/CTA targets were updated (search verification completed with ripgrep).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def575c61c8329a7b85cbad212fe52)