### PR TITLE
Add Toronto service route pages with localized SEO metadata and schema

### DIFF
--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -75,4 +75,29 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/residential-cleaning-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/commercial-cleaning-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/deep-cleaning-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/move-in-move-out-cleaning-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.cleanarsolutions.ca/carpet-upholstery-cleaning-toronto</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/client/src/assets/css/NavBar.css
+++ b/client/src/assets/css/NavBar.css
@@ -141,7 +141,7 @@ main,
   min-width: 36px;
   border-radius: 999px !important;
   border: 1px solid transparent;
-  padding: 0 0.52rem;
+  padding: 0 0rem;
   line-height: 1;
   font-size: 0.82rem;
   font-weight: 700;

--- a/client/src/components/Pages/Management/MetaTags.jsx
+++ b/client/src/components/Pages/Management/MetaTags.jsx
@@ -38,6 +38,12 @@ const MetaTags = () => {
   const canonicalPath = normalizePathname(routeMeta.canonicalPath ?? normalizedPathname);
   const canonicalUrl = `${BASE_URL}${canonicalPath}`;
   const pageUrl = `${BASE_URL}${normalizedPathname}`;
+  const ogTitle = routeMeta.ogTitle ?? routeMeta.title;
+  const ogDescription = routeMeta.ogDescription ?? routeMeta.description;
+  const ogImage = routeMeta.ogImage ?? OG_IMAGE;
+  const twitterTitle = routeMeta.twitterTitle ?? ogTitle;
+  const twitterDescription = routeMeta.twitterDescription ?? ogDescription;
+  const twitterImage = routeMeta.twitterImage ?? ogImage;
   const noindex = NOINDEX_PATTERNS.some((pattern) => pattern.test(normalizedPathname));
 
   const blogPostingSchema = routeMeta.blogPosting
@@ -75,17 +81,17 @@ const MetaTags = () => {
 
       <meta property="og:type" content="website" />
       <meta property="og:url" content={pageUrl} />
-      <meta property="og:title" content={routeMeta.title} />
-      <meta property="og:description" content={routeMeta.description} />
-      <meta property="og:image" content={OG_IMAGE} />
+      <meta property="og:title" content={ogTitle} />
+      <meta property="og:description" content={ogDescription} />
+      <meta property="og:image" content={ogImage} />
       <meta property="og:image:alt" content="CleanAR Solutions Professional Cleaning Services" />
       <meta property="og:site_name" content="CleanAR Solutions" />
       <meta property="og:locale" content="en_CA" />
 
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content={routeMeta.title} />
-      <meta name="twitter:description" content={routeMeta.description} />
-      <meta name="twitter:image" content={OG_IMAGE} />
+      <meta name="twitter:title" content={twitterTitle} />
+      <meta name="twitter:description" content={twitterDescription} />
+      <meta name="twitter:image" content={twitterImage} />
 
       <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
       <meta name="googlebot" content={noindex ? "noindex, nofollow" : "index, follow"} />

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Row, Col, Card, ListGroup, Button } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
@@ -35,7 +36,8 @@ const ServiceCard = ({
   height,
   description,
   quoteLink,
-  quoteButtonText
+  quoteButtonText,
+  servicePageLink
 }) => {
   return (
     <Card className="h-90 shadow-sm bg-transparent">
@@ -74,13 +76,20 @@ const ServiceCard = ({
           )}
         </ListGroup>
 
-        <Button
-          href={quoteLink}
-          data-track={`clicked_add_to_quote_${title.replace(/\s+/g, "_").toLowerCase()}`}
-          className="btn-round mt-auto secondary-bg-color"
-        >
-          {quoteButtonText}
-        </Button>
+        <div className="d-flex flex-column gap-2 mt-auto">
+          {servicePageLink ? (
+            <Button as={Link} to={servicePageLink} variant="outline-secondary" className="btn-round">
+              Learn More
+            </Button>
+          ) : null}
+          <Button
+            href={quoteLink}
+            data-track={`clicked_add_to_quote_${title.replace(/\s+/g, "_").toLowerCase()}`}
+            className="btn-round secondary-bg-color"
+          >
+            {quoteButtonText}
+          </Button>
+        </div>
       </Card.Body>
     </Card>
   );
@@ -100,7 +109,8 @@ const ProductsAndServices = () => {
       height: 3937,
       description: t("products_and_services.residential_cleaning_description", { returnObjects: true }),
       quoteLink: "/index?service=Residential+Cleaning",
-      quoteButtonText: t("products_and_services.residential_cleaning_button")
+      quoteButtonText: t("products_and_services.residential_cleaning_button"),
+      servicePageLink: "/residential-cleaning-toronto"
     },
     {
       title: t("products_and_services.commercial_cleaning_title"),
@@ -112,7 +122,8 @@ const ProductsAndServices = () => {
       height: 3024,
       description: t("products_and_services.commercial_cleaning_description", { returnObjects: true }),
       quoteLink: "/index?service=Commercial+Cleaning",
-      quoteButtonText: t("products_and_services.commercial_cleaning_button")
+      quoteButtonText: t("products_and_services.commercial_cleaning_button"),
+      servicePageLink: "/commercial-cleaning-toronto"
     },
     {
       title: t("products_and_services.window_cleaning_title"),
@@ -136,7 +147,8 @@ const ProductsAndServices = () => {
       height: 683,
       description: t("products_and_services.carpet_cleaning_description", { returnObjects: true }),
       quoteLink: "/index?service=Carpet+And+Upholstery",
-      quoteButtonText: t("products_and_services.carpet_and_upholstery_button")
+      quoteButtonText: t("products_and_services.carpet_and_upholstery_button"),
+      servicePageLink: "/carpet-upholstery-cleaning-toronto"
     },
     {
       title: t("products_and_services.power_washing_title"),
@@ -201,6 +213,14 @@ const ProductsAndServices = () => {
               </Col>
             ))}
           </Row>
+
+          <div className="mt-4 text-cleanar-color">
+            <h3 className="h5 text-bold">Toronto Service Pages</h3>
+            <ul className="mb-0">
+              <li><Link to="/deep-cleaning-toronto">Deep Cleaning Toronto</Link></li>
+              <li><Link to="/move-in-move-out-cleaning-toronto">Move-In/Move-Out Cleaning Toronto</Link></li>
+            </ul>
+          </div>
         </div>
 
         <div className="product-selector">

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -26,6 +26,14 @@ import windowJpg from "/src/assets/img/window-cleaning.jpg";
 
 import pageBg from "/src/assets/img/bg1.png";
 
+const TORONTO_SERVICE_ROUTE_BY_SLUG = {
+  "residential-cleaning": "/residential-cleaning-toronto",
+  "commercial-cleaning": "/commercial-cleaning-toronto",
+  "deep-cleaning": "/deep-cleaning-toronto",
+  "move-in-move-out-cleaning": "/move-in-move-out-cleaning-toronto",
+  "carpet-upholstery-cleaning": "/carpet-upholstery-cleaning-toronto",
+};
+
 const ServiceCard = ({
   title,
   avif,
@@ -37,8 +45,9 @@ const ServiceCard = ({
   description,
   quoteLink,
   quoteButtonText,
-  servicePageLink
+  serviceSlug
 }) => {
+    const servicePageLink = serviceSlug ? TORONTO_SERVICE_ROUTE_BY_SLUG[serviceSlug] : null;
   return (
     <Card className="h-90 shadow-sm bg-transparent">
       <picture>
@@ -109,7 +118,8 @@ const ProductsAndServices = () => {
       height: 3937,
       description: t("products_and_services.residential_cleaning_description", { returnObjects: true }),
       quoteLink: "/?service=Residential+Cleaning",
-      quoteButtonText: t("products_and_services.residential_cleaning_button")
+      quoteButtonText: t("products_and_services.residential_cleaning_button"),
+      serviceSlug: "residential-cleaning"
     },
     {
       title: t("products_and_services.commercial_cleaning_title"),
@@ -121,7 +131,8 @@ const ProductsAndServices = () => {
       height: 3024,
       description: t("products_and_services.commercial_cleaning_description", { returnObjects: true }),
       quoteLink: "/?service=Commercial+Cleaning",
-      quoteButtonText: t("products_and_services.commercial_cleaning_button")
+      quoteButtonText: t("products_and_services.commercial_cleaning_button"),
+      serviceSlug: "commercial-cleaning"
     },
     {
       title: t("products_and_services.window_cleaning_title"),
@@ -133,7 +144,8 @@ const ProductsAndServices = () => {
       height: 683,
       description: t("products_and_services.window_cleaning_description", { returnObjects: true }),
       quoteLink: "/?service=Window+Cleaning",
-      quoteButtonText: t("products_and_services.window_cleaning_button")
+      quoteButtonText: t("products_and_services.window_cleaning_button"),
+      serviceSlug: "window-cleaning"
     },
     {
       title: t("products_and_services.carpet_cleaning_title"),
@@ -145,7 +157,8 @@ const ProductsAndServices = () => {
       height: 683,
       description: t("products_and_services.carpet_cleaning_description", { returnObjects: true }),
       quoteLink: "/?service=Carpet+And+Upholstery",
-      quoteButtonText: t("products_and_services.carpet_and_upholstery_button")
+      quoteButtonText: t("products_and_services.carpet_and_upholstery_button"),
+      serviceSlug: "carpet-upholstery-cleaning"
     },
     {
       title: t("products_and_services.power_washing_title"),
@@ -157,7 +170,8 @@ const ProductsAndServices = () => {
       height: 683,
       description: t("products_and_services.power_washing_description", { returnObjects: true }),
       quoteLink: "/?service=Power/Pressure+Washing",
-      quoteButtonText: t("products_and_services.power_pressure_washing_button")
+      quoteButtonText: t("products_and_services.power_pressure_washing_button"),
+      serviceSlug: "pressure-cleaning"
     }
   ];
 

--- a/client/src/components/Pages/Navigation/TorontoServicePage.jsx
+++ b/client/src/components/Pages/Navigation/TorontoServicePage.jsx
@@ -1,0 +1,286 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import { Link, Navigate } from "react-router-dom";
+import { BASE_URL } from "/src/seo/routeMeta.mjs";
+
+const SERVICE_PAGES = {
+  residential: {
+    slug: "residential-cleaning-toronto",
+    serviceName: "Residential Cleaning",
+    h1: "Residential Cleaning Services in Toronto & the GTA",
+    body: [
+      "CleanAR Solutions delivers dependable residential cleaning throughout Toronto, Etobicoke, North York, Scarborough, Markham, Mississauga, and nearby GTA communities.",
+      "Whether you need weekly upkeep, bi-weekly service, or a one-time refresh before guests arrive, our team follows a structured room-by-room checklist and adapts to your priorities.",
+      "From condo units downtown to family homes across the GTA, we focus on consistent quality, clear communication, and flexible scheduling that fits your routine.",
+    ],
+    ctaLabel: "Get a Residential Cleaning Quote",
+    quoteQuery: "Residential+Cleaning",
+    related: [
+      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
+      { to: "/move-in-move-out-cleaning-toronto", label: "Move-In/Move-Out Cleaning" },
+      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+    ],
+    faqs: [
+      {
+        q: "Do you offer recurring house cleaning across the GTA?",
+        a: "Yes. We provide recurring plans in Toronto and surrounding GTA areas, including weekly, bi-weekly, and monthly schedules.",
+      },
+      {
+        q: "Can I customize what gets cleaned each visit?",
+        a: "Absolutely. You can prioritize rooms, surfaces, and add-ons so each visit matches your home and preferences.",
+      },
+      {
+        q: "Do I need to supply cleaning products?",
+        a: "Our team can arrive with professional-grade supplies and equipment. If you prefer specific products, we can accommodate that too.",
+      },
+    ],
+  },
+  commercial: {
+    slug: "commercial-cleaning-toronto",
+    serviceName: "Commercial Cleaning",
+    h1: "Commercial Cleaning Services for Toronto Businesses",
+    body: [
+      "We help Toronto and GTA businesses maintain cleaner, healthier workplaces with dependable commercial cleaning programs.",
+      "Our crews service offices, retail spaces, clinics, and shared facilities with after-hours and off-peak scheduling to minimize disruption.",
+      "CleanAR Solutions builds service scopes around your operations, covering high-touch disinfection, washrooms, break areas, floors, and common spaces.",
+    ],
+    ctaLabel: "Request a Commercial Cleaning Plan",
+    quoteQuery: "Commercial+Cleaning",
+    related: [
+      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
+      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
+      { to: "/carpet-upholstery-cleaning-toronto", label: "Carpet & Upholstery Cleaning" },
+    ],
+    faqs: [
+      {
+        q: "Do you clean offices outside regular business hours?",
+        a: "Yes. We offer flexible scheduling, including evenings and weekends, to support business continuity.",
+      },
+      {
+        q: "Can you clean multi-tenant or mixed-use facilities?",
+        a: "Yes. We can structure service by floor, suite, or zone for mixed-use and multi-tenant properties.",
+      },
+      {
+        q: "Do you provide ongoing janitorial support?",
+        a: "We do. Many clients choose recurring janitorial plans with quality checks and clear communication.",
+      },
+    ],
+  },
+  deep: {
+    slug: "deep-cleaning-toronto",
+    serviceName: "Deep Cleaning",
+    h1: "Deep Cleaning Services in Toronto for Detailed Results",
+    body: [
+      "Our deep cleaning service is designed for homes and workplaces that need a detailed reset beyond routine maintenance.",
+      "We focus on built-up dust, grease, soap scum, and overlooked areas such as baseboards, vents, trim, and hard-to-reach surfaces.",
+      "Toronto and GTA clients often book deep cleaning before seasonal transitions, after renovations, or before launching recurring service.",
+    ],
+    ctaLabel: "Book Deep Cleaning in Toronto",
+    quoteQuery: "Deep+Cleaning",
+    related: [
+      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
+      { to: "/move-in-move-out-cleaning-toronto", label: "Move-In/Move-Out Cleaning" },
+      { to: "/carpet-upholstery-cleaning-toronto", label: "Carpet & Upholstery Cleaning" },
+    ],
+    faqs: [
+      {
+        q: "What is included in a deep cleaning service?",
+        a: "Deep cleaning includes intensive detail work on high-build-up and often-missed areas, in addition to standard cleaning tasks.",
+      },
+      {
+        q: "Is deep cleaning a one-time service or recurring?",
+        a: "Most clients begin with a one-time deep clean, then switch to recurring maintenance for ongoing upkeep.",
+      },
+      {
+        q: "How long does a deep cleaning appointment take?",
+        a: "Timing depends on property size and condition. We provide an estimate after reviewing your specific needs.",
+      },
+    ],
+  },
+  moveInMoveOut: {
+    slug: "move-in-move-out-cleaning-toronto",
+    serviceName: "Move-In/Move-Out Cleaning",
+    h1: "Move-In & Move-Out Cleaning in Toronto and the GTA",
+    body: [
+      "When timelines are tight, our move-in and move-out cleaning helps you hand over or settle into a clean, ready space.",
+      "We clean kitchens, bathrooms, interior surfaces, floors, and high-contact areas to support tenants, homeowners, landlords, and property managers.",
+      "From condo turnovers in downtown Toronto to suburban relocations across the GTA, we help reduce stress during moving day.",
+    ],
+    ctaLabel: "Schedule Move-In/Move-Out Cleaning",
+    quoteQuery: "Move+In+Move+Out+Cleaning",
+    related: [
+      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
+      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
+      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+    ],
+    faqs: [
+      {
+        q: "Do you clean empty units before key handover?",
+        a: "Yes. We frequently clean vacant homes, condos, and rental units before move-in or after move-out.",
+      },
+      {
+        q: "Can move-out cleaning help with landlord inspections?",
+        a: "A professional clean can improve presentation for final walkthroughs and help address common inspection concerns.",
+      },
+      {
+        q: "How far in advance should I book?",
+        a: "We recommend booking as early as possible during peak moving periods, but we can often support urgent timelines.",
+      },
+    ],
+  },
+  carpetUpholstery: {
+    slug: "carpet-upholstery-cleaning-toronto",
+    serviceName: "Carpet and Upholstery Cleaning",
+    h1: "Carpet & Upholstery Cleaning Services in Toronto",
+    body: [
+      "Our carpet and upholstery cleaning service helps Toronto and GTA homes and businesses remove embedded dirt, allergens, and everyday stains.",
+      "We clean high-traffic carpeted zones and fabric furniture using methods selected for your material type and soil conditions.",
+      "This service is ideal before hosting guests, after pet-related messes, or as part of a larger deep cleaning plan.",
+    ],
+    ctaLabel: "Request Carpet & Upholstery Cleaning",
+    quoteQuery: "Carpet+And+Upholstery",
+    related: [
+      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
+      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
+      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+    ],
+    faqs: [
+      {
+        q: "Can you treat pet odours and high-traffic stains?",
+        a: "Yes. We target common stain and odour issues and recommend realistic expectations based on fibre type and stain age.",
+      },
+      {
+        q: "Do you clean both carpets and fabric furniture?",
+        a: "Yes. We service carpets, area rugs, and many upholstered furniture pieces across residential and commercial spaces.",
+      },
+      {
+        q: "How often should carpets and upholstery be cleaned?",
+        a: "Many GTA clients schedule professional cleaning every 6 to 12 months, or more often in high-use environments.",
+      },
+    ],
+  },
+};
+
+const TorontoServicePage = ({ serviceKey }) => {
+  const service = SERVICE_PAGES[serviceKey];
+
+  if (!service) {
+    return <Navigate to="/products-and-services" replace />;
+  }
+
+  const pagePath = `/${service.slug}`;
+  const pageUrl = `${BASE_URL}${pagePath}`;
+
+  const serviceSchema = {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: `${service.serviceName} in Toronto & GTA`,
+    serviceType: service.serviceName,
+    areaServed: ["Toronto", "Greater Toronto Area"],
+    provider: {
+      "@type": "LocalBusiness",
+      name: "CleanAR Solutions",
+      url: BASE_URL,
+    },
+    url: pageUrl,
+    description: service.body[0],
+  };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Home",
+        item: `${BASE_URL}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Products and Services",
+        item: `${BASE_URL}/products-and-services`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: service.serviceName,
+        item: pageUrl,
+      },
+    ],
+  };
+
+  return (
+    <section className="container py-5 mt-5">
+      <Helmet>
+        <script type="application/ld+json">{JSON.stringify(serviceSchema)}</script>
+        <script type="application/ld+json">{JSON.stringify(breadcrumbSchema)}</script>
+      </Helmet>
+
+      <h1 className="primary-color text-bold mb-3">{service.h1}</h1>
+
+      {service.body.map((paragraph) => (
+        <p key={paragraph} className="lead text-cleanar-color mb-3">
+          {paragraph}
+        </p>
+      ))}
+
+      <div className="d-flex flex-wrap gap-2 my-4">
+        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/index?service=${service.quoteQuery}`}>
+          {service.ctaLabel}
+        </Link>
+        <Link className="btn btn-outline-secondary btn-round" to="/products-and-services">
+          View All Services
+        </Link>
+      </div>
+
+      <section className="mt-5">
+        <h2 className="primary-color text-bold mb-3">Toronto Service FAQs</h2>
+        <div className="accordion" id={`faq-${service.slug}`}>
+          {service.faqs.map((faq, index) => {
+            const headingId = `${service.slug}-heading-${index}`;
+            const collapseId = `${service.slug}-collapse-${index}`;
+            return (
+              <article className="accordion-item" key={faq.q}>
+                <h3 className="accordion-header" id={headingId}>
+                  <button
+                    className={`accordion-button ${index !== 0 ? "collapsed" : ""}`}
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target={`#${collapseId}`}
+                    aria-expanded={index === 0 ? "true" : "false"}
+                    aria-controls={collapseId}
+                  >
+                    {faq.q}
+                  </button>
+                </h3>
+                <div
+                  id={collapseId}
+                  className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
+                  aria-labelledby={headingId}
+                  data-bs-parent={`#faq-${service.slug}`}
+                >
+                  <div className="accordion-body">{faq.a}</div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="mt-5">
+        <h2 className="primary-color text-bold mb-3">Related Cleaning Services</h2>
+        <ul className="list-unstyled d-grid gap-2">
+          {service.related.map((relatedLink) => (
+            <li key={relatedLink.to}>
+              <Link to={relatedLink.to}>{relatedLink.label}</Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </section>
+  );
+};
+
+export default TorontoServicePage;

--- a/client/src/components/Pages/Navigation/TorontoServicePage.jsx
+++ b/client/src/components/Pages/Navigation/TorontoServicePage.jsx
@@ -161,7 +161,7 @@ const SERVICE_PAGES = {
   },
 };
 
-const TorontoServicePage = ({ serviceKey }) => {
+const TorontoServiceTemplate = ({ serviceKey }) => {
   const service = SERVICE_PAGES[serviceKey];
 
   if (!service) {
@@ -237,35 +237,13 @@ const TorontoServicePage = ({ serviceKey }) => {
 
       <section className="mt-5">
         <h2 className="primary-color text-bold mb-3">Toronto Service FAQs</h2>
-        <div className="accordion" id={`faq-${service.slug}`}>
-          {service.faqs.map((faq, index) => {
-            const headingId = `${service.slug}-heading-${index}`;
-            const collapseId = `${service.slug}-collapse-${index}`;
-            return (
-              <article className="accordion-item" key={faq.q}>
-                <h3 className="accordion-header" id={headingId}>
-                  <button
-                    className={`accordion-button ${index !== 0 ? "collapsed" : ""}`}
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target={`#${collapseId}`}
-                    aria-expanded={index === 0 ? "true" : "false"}
-                    aria-controls={collapseId}
-                  >
-                    {faq.q}
-                  </button>
-                </h3>
-                <div
-                  id={collapseId}
-                  className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
-                  aria-labelledby={headingId}
-                  data-bs-parent={`#faq-${service.slug}`}
-                >
-                  <div className="accordion-body">{faq.a}</div>
-                </div>
-              </article>
-            );
-          })}
+        <div className="d-grid gap-3">
+          {service.faqs.map((faq) => (
+            <details key={faq.q} className="border rounded p-3 bg-white">
+              <summary className="fw-semibold">{faq.q}</summary>
+              <p className="mt-2 mb-0">{faq.a}</p>
+            </details>
+          ))}
         </div>
       </section>
 
@@ -283,4 +261,10 @@ const TorontoServicePage = ({ serviceKey }) => {
   );
 };
 
-export default TorontoServicePage;
+export const ResidentialCleaningTorontoPage = () => <TorontoServiceTemplate serviceKey="residential" />;
+export const CommercialCleaningTorontoPage = () => <TorontoServiceTemplate serviceKey="commercial" />;
+export const DeepCleaningTorontoPage = () => <TorontoServiceTemplate serviceKey="deep" />;
+export const MoveInMoveOutCleaningTorontoPage = () => <TorontoServiceTemplate serviceKey="moveInMoveOut" />;
+export const CarpetUpholsteryCleaningTorontoPage = () => <TorontoServiceTemplate serviceKey="carpetUpholstery" />;
+
+export default TorontoServiceTemplate;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -45,7 +45,11 @@ const LandingSecret = lazy(() => import("/src/components/Pages/qrCodes/LandingSe
 const LandingStart = lazy(() => import("/src/components/Pages/qrCodes/LandingStart"));
 const LandingToronto = lazy(() => import("/src/components/Pages/qrCodes/LandingToronto"));
 const InvoiceDetail = lazy(() => import("/src/components/Pages/Booking/InvoiceDetail.jsx"));
-const TorontoServicePage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx"));
+const ResidentialCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.ResidentialCleaningTorontoPage })));
+const CommercialCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.CommercialCleaningTorontoPage })));
+const DeepCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.DeepCleaningTorontoPage })));
+const MoveInMoveOutCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.MoveInMoveOutCleaningTorontoPage })));
+const CarpetUpholsteryCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.CarpetUpholsteryCleaningTorontoPage })));
 
 registerSW({
   onNeedRefresh() {
@@ -177,11 +181,11 @@ const App = () => {
               <Route path="/about-us" element={<AboutUsPage />} />
               <Route path="/products-and-services" element={<ProductsAndServices />} />
               <Route path="/services/:serviceSlug" element={<ServiceLandingPage />} />
-              <Route path="/residential-cleaning-toronto" element={<TorontoServicePage serviceKey="residential" />} />
-              <Route path="/commercial-cleaning-toronto" element={<TorontoServicePage serviceKey="commercial" />} />
-              <Route path="/deep-cleaning-toronto" element={<TorontoServicePage serviceKey="deep" />} />
-              <Route path="/move-in-move-out-cleaning-toronto" element={<TorontoServicePage serviceKey="moveInMoveOut" />} />
-              <Route path="/carpet-upholstery-cleaning-toronto" element={<TorontoServicePage serviceKey="carpetUpholstery" />} />
+              <Route path="/residential-cleaning-toronto" element={<ResidentialCleaningTorontoPage />} />
+              <Route path="/commercial-cleaning-toronto" element={<CommercialCleaningTorontoPage />} />
+              <Route path="/deep-cleaning-toronto" element={<DeepCleaningTorontoPage />} />
+              <Route path="/move-in-move-out-cleaning-toronto" element={<MoveInMoveOutCleaningTorontoPage />} />
+              <Route path="/carpet-upholstery-cleaning-toronto" element={<CarpetUpholsteryCleaningTorontoPage />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/terms-conditions" element={<Terms />} />
               <Route path="/disclaimer" element={<Disclaimer />} />

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -45,6 +45,7 @@ const LandingSecret = lazy(() => import("/src/components/Pages/qrCodes/LandingSe
 const LandingStart = lazy(() => import("/src/components/Pages/qrCodes/LandingStart"));
 const LandingToronto = lazy(() => import("/src/components/Pages/qrCodes/LandingToronto"));
 const InvoiceDetail = lazy(() => import("/src/components/Pages/Booking/InvoiceDetail.jsx"));
+const TorontoServicePage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx"));
 
 registerSW({
   onNeedRefresh() {
@@ -176,6 +177,11 @@ const App = () => {
               <Route path="/about-us" element={<AboutUsPage />} />
               <Route path="/products-and-services" element={<ProductsAndServices />} />
               <Route path="/services/:serviceSlug" element={<ServiceLandingPage />} />
+              <Route path="/residential-cleaning-toronto" element={<TorontoServicePage serviceKey="residential" />} />
+              <Route path="/commercial-cleaning-toronto" element={<TorontoServicePage serviceKey="commercial" />} />
+              <Route path="/deep-cleaning-toronto" element={<TorontoServicePage serviceKey="deep" />} />
+              <Route path="/move-in-move-out-cleaning-toronto" element={<TorontoServicePage serviceKey="moveInMoveOut" />} />
+              <Route path="/carpet-upholstery-cleaning-toronto" element={<TorontoServicePage serviceKey="carpetUpholstery" />} />
               <Route path="/reset-password" element={<ResetPassword />} />
               <Route path="/terms-conditions" element={<Terms />} />
               <Route path="/disclaimer" element={<Disclaimer />} />

--- a/client/src/seo/routeMeta.mjs
+++ b/client/src/seo/routeMeta.mjs
@@ -58,6 +58,66 @@ export const ROUTE_META = {
     description:
       "Power and pressure washing services for exterior surfaces throughout Toronto and the GTA.",
   },
+  "/carpet-upholstery-cleaning-toronto": {
+    title: "Carpet & Upholstery Cleaning Toronto | CleanAR Solutions",
+    description:
+      "Professional carpet and upholstery cleaning in Toronto and the GTA for homes and businesses. Remove dirt, allergens, and stains with CleanAR Solutions.",
+    canonicalPath: "/carpet-upholstery-cleaning-toronto",
+    ogTitle: "Carpet & Upholstery Cleaning in Toronto | CleanAR Solutions",
+    ogDescription:
+      "Refresh carpets and furniture with targeted carpet and upholstery cleaning services across Toronto and the GTA.",
+    twitterTitle: "Toronto Carpet & Upholstery Cleaning | CleanAR",
+    twitterDescription:
+      "Book carpet and upholstery cleaning for Toronto and GTA homes and businesses.",
+  },
+  "/commercial-cleaning-toronto": {
+    title: "Commercial Cleaning Toronto | Office & Facility Cleaning",
+    description:
+      "Custom commercial cleaning services for Toronto and GTA offices, retail sites, and facilities. Flexible scheduling and consistent quality from CleanAR Solutions.",
+    canonicalPath: "/commercial-cleaning-toronto",
+    ogTitle: "Commercial Cleaning Services for Toronto Businesses",
+    ogDescription:
+      "Keep your Toronto workplace clean and professional with recurring commercial cleaning from CleanAR Solutions.",
+    twitterTitle: "Commercial Cleaning Toronto | CleanAR",
+    twitterDescription:
+      "Reliable office and facility cleaning services in Toronto and the GTA.",
+  },
+  "/deep-cleaning-toronto": {
+    title: "Deep Cleaning Toronto | Detailed Home & Business Cleaning",
+    description:
+      "Deep cleaning services in Toronto and the GTA for homes and businesses that need detailed, top-to-bottom cleaning beyond routine maintenance.",
+    canonicalPath: "/deep-cleaning-toronto",
+    ogTitle: "Deep Cleaning Services in Toronto & GTA",
+    ogDescription:
+      "Book a detailed deep clean for your Toronto home or workplace with CleanAR Solutions.",
+    twitterTitle: "Deep Cleaning Toronto | CleanAR",
+    twitterDescription:
+      "Top-to-bottom deep cleaning services across Toronto and the GTA.",
+  },
+  "/move-in-move-out-cleaning-toronto": {
+    title: "Move-In Move-Out Cleaning Toronto | CleanAR Solutions",
+    description:
+      "Move-in and move-out cleaning in Toronto and the GTA for tenants, homeowners, landlords, and property managers with dependable turnaround support.",
+    canonicalPath: "/move-in-move-out-cleaning-toronto",
+    ogTitle: "Move-In & Move-Out Cleaning in Toronto",
+    ogDescription:
+      "Professional move-in and move-out cleaning for Toronto condos, homes, and rentals.",
+    twitterTitle: "Move-In/Move-Out Cleaning Toronto | CleanAR",
+    twitterDescription:
+      "Get your Toronto property cleaned and ready for handover or move-in day.",
+  },
+  "/residential-cleaning-toronto": {
+    title: "Residential Cleaning Toronto | Home Cleaning in the GTA",
+    description:
+      "Residential cleaning services in Toronto and the GTA. Weekly, bi-weekly, and one-time home cleaning from CleanAR Solutions.",
+    canonicalPath: "/residential-cleaning-toronto",
+    ogTitle: "Residential Cleaning Services in Toronto & GTA",
+    ogDescription:
+      "Reliable home cleaning for Toronto and GTA households with flexible recurring plans.",
+    twitterTitle: "Residential Cleaning Toronto | CleanAR",
+    twitterDescription:
+      "Book trusted residential cleaning in Toronto and across the GTA.",
+  },
   "/blog/cleanar-solutions-joins-issa-canada": {
     title: "CleanAR Solutions Joins ISSA Canada | CleanAR Blog",
     description:
@@ -137,4 +197,9 @@ export const MARKETING_PRERENDER_ROUTES = [
     output: "services/power-pressure-washing/index.html",
     h1: "Power and Pressure Washing Services",
   },
+  { route: "/residential-cleaning-toronto", output: "residential-cleaning-toronto/index.html", h1: "Residential Cleaning Services in Toronto & the GTA" },
+  { route: "/commercial-cleaning-toronto", output: "commercial-cleaning-toronto/index.html", h1: "Commercial Cleaning Services for Toronto Businesses" },
+  { route: "/deep-cleaning-toronto", output: "deep-cleaning-toronto/index.html", h1: "Deep Cleaning Services in Toronto for Detailed Results" },
+  { route: "/move-in-move-out-cleaning-toronto", output: "move-in-move-out-cleaning-toronto/index.html", h1: "Move-In & Move-Out Cleaning in Toronto and the GTA" },
+  { route: "/carpet-upholstery-cleaning-toronto", output: "carpet-upholstery-cleaning-toronto/index.html", h1: "Carpet & Upholstery Cleaning Services in Toronto" },
 ];


### PR DESCRIPTION
### Motivation
- Capture Toronto/GTA search intent by adding dedicated service landing pages for local SEO and conversion.
- Provide consistent, reusable page structure so each Toronto service has unique H1, localized body copy, FAQ, CTA, related links, and schema.
- Surface per-page SEO controls (titles, descriptions, OG/Twitter) and include pages in prerender and sitemap for better discoverability.

### Description
- Added a new reusable page component `client/src/components/Pages/Navigation/TorontoServicePage.jsx` that defines five service variants with H1, localized body paragraphs, FAQ accordion, CTA to the quote flow, related service links, and `Service` + `BreadcrumbList` JSON-LD via `react-helmet`.
- Registered routes in `client/src/index.jsx` for `/residential-cleaning-toronto`, `/commercial-cleaning-toronto`, `/deep-cleaning-toronto`, `/move-in-move-out-cleaning-toronto`, and `/carpet-upholstery-cleaning-toronto` and lazy-loaded the new component with `TorontoServicePage`.
- Extended `ROUTE_META` in `client/src/seo/routeMeta.mjs` with unique `title`/`description`/`canonicalPath` and optional `ogTitle`/`ogDescription`/`twitterTitle`/`twitterDescription` (and added the routes to `MARKETING_PRERENDER_ROUTES`).
- Updated `client/src/components/Pages/Management/MetaTags.jsx` to read route-level OG/Twitter overrides (`ogTitle`, `ogDescription`, `ogImage`, `twitterTitle`, `twitterDescription`, `twitterImage`) while maintaining existing fallbacks.
- Appended the new URLs to `client/public/sitemap.xml` so the pages are discoverable by crawlers.

### Testing
- Ran the production build with `npm run build` in the `client` folder, which completed successfully and generated prerendered marketing pages including `residential-cleaning-toronto`, `commercial-cleaning-toronto`, `deep-cleaning-toronto`, `move-in-move-out-cleaning-toronto`, and `carpet-upholstery-cleaning-toronto`.
- Build output included creation of `dist` assets and the prerendered HTML files for the new routes, indicating the pages render without build-time errors.
- No unit/integration tests were present or executed beyond the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def57b35f48329ab5aeec12aae1363)