### PR TITLE
Refactor route-based JSON-LD injection and validation

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -81,49 +81,28 @@
   </script>
   <script src="https://analytics.ahrefs.com/analytics.js" data-key="uBTWwx1doWAXuF07h1ukDA" defer="true"></script> -->
 
-  <!-- ✅ SEO Structured Data (LocalBusiness with AggregateRating) -->
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "LocalBusiness",
-  "name": "CleanAR Solutions",
-  "image": "https://www.cleanarsolutions.ca/logo.png",
-  "url": "https://www.cleanarsolutions.ca/",
-  "telephone": "+1-437-440-5514",
-  "address": {
-    "@type": "PostalAddress",
-    "streetAddress": "414 Jarvis St",
-    "addressLocality": "Toronto",
-    "addressRegion": "ON",
-    "postalCode": "M4Y 3C2",
-    "addressCountry": "CA"
-  },
-  "aggregateRating": {
-    "@type": "AggregateRating",
-    "ratingValue": "5.0",
-    "reviewCount": "11"
-  },
-  "memberOf": [
-    {
-      "@type": "Organization",
-      "name": "ISSA Canada",
-      "url": "https://www.issa-canada.com/en/"
-    }
-  ],
-  "hasCredential": [
-    {
-      "@type": "EducationalOccupationalCredential",
-      "name": "LGBTQ+ Certified Supplier",
-      "credentialCategory": "Certification",
-      "recognizedBy": {
-        "@type": "Organization",
-        "name": "CQCC",
-        "url": "https://queerchamber.ca/"
-      }
-    }
-  ]
-}
-</script>
+  <!-- Minimal fallback structured data (route-specific schema is injected by MetaTags/prerender) -->
+  <script id="site-jsonld-fallback" type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "CleanAR Solutions",
+    "url": "https://www.cleanarsolutions.ca/",
+    "telephone": "+1-437-440-5514",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "414 Jarvis St",
+      "addressLocality": "Toronto",
+      "addressRegion": "ON",
+      "postalCode": "M4Y 3C2",
+      "addressCountry": "CA"
+    },
+    "areaServed": [
+      "Toronto",
+      "Greater Toronto Area"
+    ]
+  }
+  </script>
 </head>
 
 <body>

--- a/client/scripts/prerender-marketing-routes.mjs
+++ b/client/scripts/prerender-marketing-routes.mjs
@@ -5,6 +5,7 @@ import {
   OG_IMAGE,
   ROUTE_META,
   MARKETING_PRERENDER_ROUTES,
+  buildRouteStructuredData,
 } from "../src/seo/routeMeta.mjs";
 
 const DIST_DIR = path.resolve(process.cwd(), "dist");
@@ -89,6 +90,21 @@ const buildRouteHtml = (baseHtml, routeConfig, routeMeta) => {
   const noscriptContent = `<noscript>\n    <h1>${routeConfig.h1}</h1>\n    <h2>${routeMeta.description}</h2>\n  </noscript>`;
   html = html.replace(bodyNoscriptPattern, `$1${noscriptContent}`);
 
+  const routeSchemas = buildRouteStructuredData(routeConfig.route, routeMeta);
+  const routeSchemaScripts = routeSchemas
+    .map((schema, index) => {
+      const schemaType = Array.isArray(schema["@type"]) ? schema["@type"].join(",") : schema["@type"];
+      return `  <script type="application/ld+json" data-route-schema="true" data-schema-type="${schemaType}" data-schema-index="${index}">${JSON.stringify(
+        schema
+      )}</script>`;
+    })
+    .join("\n");
+  html = html.replace(/\s*<script[^>]*data-route-schema=["']true["'][^>]*>[\s\S]*?<\/script>/gi, "");
+  html = html.replace(
+    /<\/head>/i,
+    `${routeSchemaScripts ? `${routeSchemaScripts}\n` : ""}</head>`
+  );
+
   return html;
 };
 
@@ -112,6 +128,34 @@ const validateRouteHtml = (html, routeConfig, routeMeta) => {
     throw new Error(
       `Prerender validation failed for route ${routeConfig.route}: missing ${missing.join(", ")}`
     );
+  }
+
+  const expectedSchemas = buildRouteStructuredData(routeConfig.route, routeMeta);
+  const schemaTypeCounts = {
+    cleaningServiceOrLocalBusiness: (
+      html.match(/data-schema-type=["'][^"']*(CleaningService|LocalBusiness)[^"']*["']/g) || []
+    ).length,
+    service: (html.match(/data-schema-type=["']Service["']/g) || []).length,
+    breadcrumbList: (html.match(/data-schema-type=["']BreadcrumbList["']/g) || []).length,
+  };
+  const expectedCounts = {
+    cleaningServiceOrLocalBusiness: expectedSchemas.some((schema) => {
+      const type = schema["@type"];
+      return Array.isArray(type)
+        ? type.includes("CleaningService") || type.includes("LocalBusiness")
+        : type === "CleaningService" || type === "LocalBusiness";
+    })
+      ? 1
+      : 0,
+    service: expectedSchemas.some((schema) => schema["@type"] === "Service") ? 1 : 0,
+    breadcrumbList: expectedSchemas.some((schema) => schema["@type"] === "BreadcrumbList") ? 1 : 0,
+  };
+
+  const mismatch = Object.entries(expectedCounts)
+    .filter(([key, expected]) => schemaTypeCounts[key] !== expected)
+    .map(([key, expected]) => `${key} expected ${expected} found ${schemaTypeCounts[key]}`);
+  if (mismatch.length > 0) {
+    throw new Error(`Schema validation failed for route ${routeConfig.route}: ${mismatch.join("; ")}`);
   }
 };
 

--- a/client/scripts/prerender-marketing-routes.mjs
+++ b/client/scripts/prerender-marketing-routes.mjs
@@ -99,7 +99,12 @@ const buildRouteHtml = (baseHtml, routeConfig, routeMeta) => {
       )}</script>`;
     })
     .join("\n");
-  html = html.replace(/\s*<script[^>]*data-route-schema=["']true["'][^>]*>[\s\S]*?<\/script>/gi, "");
+  const routeSchemaPattern = /\s*<script[^>]*data-route-schema=["']true["'][^>]*>[\s\S]*?<\/script>/gi;
+  let previousHtml;
+  do {
+    previousHtml = html;
+    html = html.replace(routeSchemaPattern, "");
+  } while (html !== previousHtml);
   html = html.replace(
     /<\/head>/i,
     `${routeSchemaScripts ? `${routeSchemaScripts}\n` : ""}</head>`

--- a/client/src/components/Pages/Management/MetaTags.jsx
+++ b/client/src/components/Pages/Management/MetaTags.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 import { useLocation } from "react-router-dom";
-import { BASE_URL, OG_IMAGE, ROUTE_META } from "../../../seo/routeMeta.mjs";
+import { BASE_URL, OG_IMAGE, ROUTE_META, buildRouteStructuredData } from "../../../seo/routeMeta.mjs";
 
 const NOINDEX_PATTERNS = [
   /^\/admin(?:\/|$)/,
@@ -73,6 +73,10 @@ const MetaTags = () => {
         },
       }
     : null;
+  const routeStructuredData = buildRouteStructuredData(normalizedPathname, routeMeta);
+  const structuredDataSchemas = blogPostingSchema
+    ? [...routeStructuredData, blogPostingSchema]
+    : routeStructuredData;
 
   return (
     <Helmet>
@@ -99,9 +103,11 @@ const MetaTags = () => {
       <meta name="robots" content={noindex ? "noindex, nofollow" : "index, follow"} />
       <meta name="googlebot" content={noindex ? "noindex, nofollow" : "index, follow"} />
 
-      {blogPostingSchema ? (
-        <script type="application/ld+json">{JSON.stringify(blogPostingSchema)}</script>
-      ) : null}
+      {structuredDataSchemas.map((schema, index) => (
+        <script key={`route-structured-data-${index}`} type="application/ld+json">
+          {JSON.stringify(schema)}
+        </script>
+      ))}
     </Helmet>
   );
 };

--- a/client/src/components/Pages/Navigation/TorontoServicePage.jsx
+++ b/client/src/components/Pages/Navigation/TorontoServicePage.jsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { Helmet } from "react-helmet";
 import { Link, Navigate } from "react-router-dom";
-import { BASE_URL } from "/src/seo/routeMeta.mjs";
 
 const SERVICE_PAGES = {
   residential: {
@@ -168,56 +166,8 @@ const TorontoServiceTemplate = ({ serviceKey }) => {
     return <Navigate to="/products-and-services" replace />;
   }
 
-  const pagePath = `/${service.slug}`;
-  const pageUrl = `${BASE_URL}${pagePath}`;
-
-  const serviceSchema = {
-    "@context": "https://schema.org",
-    "@type": "Service",
-    name: `${service.serviceName} in Toronto & GTA`,
-    serviceType: service.serviceName,
-    areaServed: ["Toronto", "Greater Toronto Area"],
-    provider: {
-      "@type": "LocalBusiness",
-      name: "CleanAR Solutions",
-      url: BASE_URL,
-    },
-    url: pageUrl,
-    description: service.body[0],
-  };
-
-  const breadcrumbSchema = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      {
-        "@type": "ListItem",
-        position: 1,
-        name: "Home",
-        item: `${BASE_URL}/`,
-      },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: "Products and Services",
-        item: `${BASE_URL}/products-and-services`,
-      },
-      {
-        "@type": "ListItem",
-        position: 3,
-        name: service.serviceName,
-        item: pageUrl,
-      },
-    ],
-  };
-
   return (
     <section className="container py-5 mt-5">
-      <Helmet>
-        <script type="application/ld+json">{JSON.stringify(serviceSchema)}</script>
-        <script type="application/ld+json">{JSON.stringify(breadcrumbSchema)}</script>
-      </Helmet>
-
       <h1 className="primary-color text-bold mb-3">{service.h1}</h1>
 
       {service.body.map((paragraph) => (

--- a/client/src/seo/routeMeta.mjs
+++ b/client/src/seo/routeMeta.mjs
@@ -1,5 +1,26 @@
 export const BASE_URL = "https://www.cleanarsolutions.ca";
 export const OG_IMAGE = `${BASE_URL}/og-image.jpg`;
+export const ORGANIZATION_NAME = "CleanAR Solutions";
+export const ORGANIZATION_PHONE = "+1-437-440-5514";
+export const ORGANIZATION_ADDRESS = {
+  "@type": "PostalAddress",
+  streetAddress: "414 Jarvis St",
+  addressLocality: "Toronto",
+  addressRegion: "ON",
+  postalCode: "M4Y 3C2",
+  addressCountry: "CA",
+};
+export const AREA_SERVED = ["Toronto", "Greater Toronto Area"];
+
+export const MINIMAL_SITE_FALLBACK_SCHEMA = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: ORGANIZATION_NAME,
+  url: BASE_URL,
+  telephone: ORGANIZATION_PHONE,
+  address: ORGANIZATION_ADDRESS,
+  areaServed: AREA_SERVED,
+};
 
 export const ROUTE_META = {
   "/index": {
@@ -203,3 +224,178 @@ export const MARKETING_PRERENDER_ROUTES = [
   { route: "/move-in-move-out-cleaning-toronto", output: "move-in-move-out-cleaning-toronto/index.html", h1: "Move-In & Move-Out Cleaning in Toronto and the GTA" },
   { route: "/carpet-upholstery-cleaning-toronto", output: "carpet-upholstery-cleaning-toronto/index.html", h1: "Carpet & Upholstery Cleaning Services in Toronto" },
 ];
+
+const SERVICE_SCHEMA_CONFIG = {
+  "/services/residential-cleaning": {
+    name: "Residential Cleaning Services in Toronto & GTA",
+    serviceType: "Residential Cleaning",
+  },
+  "/services/commercial-cleaning": {
+    name: "Commercial Cleaning Services in Toronto & GTA",
+    serviceType: "Commercial Cleaning",
+  },
+  "/services/window-cleaning": {
+    name: "Window Cleaning Services in Toronto & GTA",
+    serviceType: "Window Cleaning",
+  },
+  "/services/carpet-and-upholstery-cleaning": {
+    name: "Carpet and Upholstery Cleaning Services in Toronto & GTA",
+    serviceType: "Carpet and Upholstery Cleaning",
+  },
+  "/services/power-pressure-washing": {
+    name: "Power and Pressure Washing Services in Toronto & GTA",
+    serviceType: "Power and Pressure Washing",
+  },
+  "/residential-cleaning-toronto": {
+    name: "Residential Cleaning Services in Toronto & GTA",
+    serviceType: "Residential Cleaning",
+  },
+  "/commercial-cleaning-toronto": {
+    name: "Commercial Cleaning Services in Toronto & GTA",
+    serviceType: "Commercial Cleaning",
+  },
+  "/deep-cleaning-toronto": {
+    name: "Deep Cleaning Services in Toronto & GTA",
+    serviceType: "Deep Cleaning",
+  },
+  "/move-in-move-out-cleaning-toronto": {
+    name: "Move-In and Move-Out Cleaning Services in Toronto & GTA",
+    serviceType: "Move-In Move-Out Cleaning",
+  },
+  "/carpet-upholstery-cleaning-toronto": {
+    name: "Carpet and Upholstery Cleaning Services in Toronto & GTA",
+    serviceType: "Carpet and Upholstery Cleaning",
+  },
+};
+
+const BREADCRUMB_CONFIG = {
+  "/products-and-services": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+  ],
+  "/services/residential-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Residential Cleaning", path: "/services/residential-cleaning" },
+  ],
+  "/services/commercial-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Commercial Cleaning", path: "/services/commercial-cleaning" },
+  ],
+  "/services/window-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Window Cleaning", path: "/services/window-cleaning" },
+  ],
+  "/services/carpet-and-upholstery-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Carpet and Upholstery Cleaning", path: "/services/carpet-and-upholstery-cleaning" },
+  ],
+  "/services/power-pressure-washing": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Power and Pressure Washing", path: "/services/power-pressure-washing" },
+  ],
+  "/blog": [
+    { name: "Home", path: "/" },
+    { name: "Blog", path: "/blog" },
+  ],
+  "/blog/cleanar-solutions-joins-issa-canada": [
+    { name: "Home", path: "/" },
+    { name: "Blog", path: "/blog" },
+    { name: "CleanAR Solutions Joins ISSA Canada", path: "/blog/cleanar-solutions-joins-issa-canada" },
+  ],
+  "/blog/cleanar-joins-cqcc": [
+    { name: "Home", path: "/" },
+    { name: "Blog", path: "/blog" },
+    { name: "CleanAR Joins CQCC as an LGBTQ+ Certified Supplier", path: "/blog/cleanar-joins-cqcc" },
+  ],
+  "/residential-cleaning-toronto": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Residential Cleaning Toronto", path: "/residential-cleaning-toronto" },
+  ],
+  "/commercial-cleaning-toronto": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Commercial Cleaning Toronto", path: "/commercial-cleaning-toronto" },
+  ],
+  "/deep-cleaning-toronto": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Deep Cleaning Toronto", path: "/deep-cleaning-toronto" },
+  ],
+  "/move-in-move-out-cleaning-toronto": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Move-In Move-Out Cleaning Toronto", path: "/move-in-move-out-cleaning-toronto" },
+  ],
+  "/carpet-upholstery-cleaning-toronto": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Carpet and Upholstery Cleaning Toronto", path: "/carpet-upholstery-cleaning-toronto" },
+  ],
+};
+
+const normalizePathname = (path) => {
+  if (!path || path === "/") return "/";
+  return path.replace(/\/+$/, "");
+};
+
+export const buildRouteStructuredData = (pathname, routeMeta) => {
+  const normalizedPathname = normalizePathname(pathname);
+  const pagePath = normalizedPathname === "/index" ? "/" : normalizedPathname;
+  const pageUrl = `${BASE_URL}${pagePath}`;
+  const schemas = [];
+
+  if (pagePath === "/") {
+    schemas.push({
+      "@context": "https://schema.org",
+      "@type": ["CleaningService", "LocalBusiness"],
+      name: ORGANIZATION_NAME,
+      url: BASE_URL,
+      telephone: ORGANIZATION_PHONE,
+      address: ORGANIZATION_ADDRESS,
+      areaServed: AREA_SERVED,
+    });
+  }
+
+  const serviceConfig = SERVICE_SCHEMA_CONFIG[pagePath];
+  if (serviceConfig) {
+    schemas.push({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: serviceConfig.name,
+      serviceType: serviceConfig.serviceType,
+      areaServed: AREA_SERVED,
+      provider: {
+        "@type": "LocalBusiness",
+        name: ORGANIZATION_NAME,
+        telephone: ORGANIZATION_PHONE,
+        address: ORGANIZATION_ADDRESS,
+        areaServed: AREA_SERVED,
+        url: BASE_URL,
+      },
+      url: pageUrl,
+      description: routeMeta?.description,
+    });
+  }
+
+  const breadcrumbItems = BREADCRUMB_CONFIG[pagePath];
+  if (breadcrumbItems) {
+    schemas.push({
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumbItems.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.name,
+        item: `${BASE_URL}${item.path}`,
+      })),
+    });
+  }
+
+  return schemas;
+};


### PR DESCRIPTION
### Motivation
- Remove heavy route-specific JSON-LD from the static shell and centralize route-aware schema generation so pages only contain the schema types they need. 
- Ensure organization data (name, phone, address, areaServed) is consistent across all emitted schema blocks and avoid duplicate/mismatched JSON-LD injection.

### Description
- Replaced the large `LocalBusiness` JSON-LD in `client/index.html` with a minimal fallback `Organization` block (`id="site-jsonld-fallback"`) containing name, phone, address and `areaServed` (Toronto / Greater Toronto Area).
- Added centralized schema config and builder in `client/src/seo/routeMeta.mjs` including `ORGANIZATION_*` constants, `SERVICE_SCHEMA_CONFIG`, `BREADCRUMB_CONFIG`, and `buildRouteStructuredData(pathname, routeMeta)` that emits: homepage `CleaningService` + `LocalBusiness`, service pages `Service`, and hierarchical pages `BreadcrumbList` (reusing consistent org contact/location fields).
- Updated runtime SEO layer in `client/src/components/Pages/Management/MetaTags.jsx` to call `buildRouteStructuredData` and inject the returned JSON-LD blocks (and still include `blogPosting` when present).
- Removed per-page JSON-LD injection from `client/src/components/Pages/Navigation/TorontoServicePage.jsx` so schema generation is owned by the centralized SEO layer.
- Extended prerendering in `client/scripts/prerender-marketing-routes.mjs` to inject route JSON-LD into prerendered HTML and to validate that expected schema types/counts appear per route (checks for homepage `CleaningService`/`LocalBusiness`, `Service`, and `BreadcrumbList`).

### Testing
- Ran the full frontend build via `npm run build` which includes the prerender step; the build completed and the prerender script produced the routes list successfully.
- The prerender validation in `client/scripts/prerender-marketing-routes.mjs` completed without errors during `npm run build` (it enforces expected schema counts per-route).
- Per-route verification run with a small Python check on the generated `dist` files confirmed expected placements: `/` (homepage schema only), `/products-and-services` (breadcrumb only), `/services/residential-cleaning` (service + breadcrumb), and `/about-us` (no homepage/service/breadcrumb), all returned OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df026f95848329804fd460896f6ac4)