### PR TITLE
Add crawlable local-intent links between homepage, services, and blog pages

### DIFF
--- a/client/src/components/Pages/Blogs/BlogLandingPage.jsx
+++ b/client/src/components/Pages/Blogs/BlogLandingPage.jsx
@@ -71,6 +71,11 @@ function BlogLandingPage() {
         icon: <FaShieldAlt className="me-2" />,
         featured: true,
         tags: ["ISSA", "Standards", "Training"],
+        serviceLinks: [
+          { to: "/commercial-cleaning-toronto", label: "commercial cleaning in Toronto" },
+          { to: "/deep-cleaning-toronto", label: "deep cleaning in Toronto" },
+        ],
+        quoteQuery: "Commercial+Cleaning",
       },
       {
         id: "cqcc-lgbtbe",
@@ -83,6 +88,11 @@ function BlogLandingPage() {
         icon: <FaBullhorn className="me-2" />,
         featured: true,
         tags: ["CQCC", "LGBTBE", "Supplier Diversity"],
+        serviceLinks: [
+          { to: "/residential-cleaning-toronto", label: "residential cleaning in Toronto" },
+          { to: "/move-in-move-out-cleaning-toronto", label: "move-in and move-out cleaning in Toronto" },
+        ],
+        quoteQuery: "Residential+Cleaning",
       },
     ],
     []
@@ -294,6 +304,20 @@ function BlogLandingPage() {
 
             <span className="small text-muted d-none d-sm-inline">{t("blog.readTime")}</span>
           </div>
+
+          {Array.isArray(post.serviceLinks) && post.serviceLinks.length ? (
+            <div className="mt-3 small">
+              <span className="fw-semibold d-block mb-1">Related services:</span>
+              <ul className="mb-2 ps-3">
+                {post.serviceLinks.map((serviceLink) => (
+                  <li key={serviceLink.to}>
+                    <Link to={serviceLink.to}>{serviceLink.label}</Link>
+                  </li>
+                ))}
+              </ul>
+              <Link to={`/?service=${post.quoteQuery}`}>request a cleaning quote in Toronto</Link>
+            </div>
+          ) : null}
         </CardBody>
       </Card>
     );

--- a/client/src/components/Pages/Blogs/CleanARJoinsCQCC.jsx
+++ b/client/src/components/Pages/Blogs/CleanARJoinsCQCC.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { Container, Row, Col } from "reactstrap";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
 import CQCCCertificationBadge from "/src/components/Pages/Certifications/CQCCCertificationBadge.jsx";
@@ -114,6 +114,27 @@ function CleanARJoinsCQCC() {
             <p className="text-secondary">
               <Trans i18nKey="blogCQCC.closing" components={{ strong: <strong /> }} />
             </p>
+
+            <section className="mt-4">
+              <h2 className="fw-bold mb-3">Related Toronto cleaning services</h2>
+              <ul>
+                <li>
+                  <Link to="/residential-cleaning-toronto">residential cleaning in Toronto</Link>
+                </li>
+                <li>
+                  <Link to="/move-in-move-out-cleaning-toronto">
+                    move-in and move-out cleaning in Toronto
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/commercial-cleaning-toronto">commercial cleaning in Toronto</Link>
+                </li>
+              </ul>
+              <p className="mb-0">
+                Need a tailored plan?{" "}
+                <Link to="/?service=Residential+Cleaning">request a cleaning quote in Toronto</Link>.
+              </p>
+            </section>
           </Col>
         </Row>
       </Container>

--- a/client/src/components/Pages/Blogs/CleanARJoinsISSACanada.jsx
+++ b/client/src/components/Pages/Blogs/CleanARJoinsISSACanada.jsx
@@ -1,7 +1,7 @@
 // src/components/Pages/Blog/CleanARJoinsISSACanada.jsx
 import React, { useEffect } from "react";
 import { Container, Row, Col } from "reactstrap";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
 
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
@@ -166,6 +166,25 @@ function CleanARJoinsISSACanada() {
                 components={{ strong: <strong /> }}
               />
             </p>
+
+            <section className="mt-4">
+              <h2 className="fw-bold mb-3">Related Toronto cleaning services</h2>
+              <ul>
+                <li>
+                  <Link to="/commercial-cleaning-toronto">commercial cleaning in Toronto</Link>
+                </li>
+                <li>
+                  <Link to="/deep-cleaning-toronto">deep cleaning in Toronto</Link>
+                </li>
+                <li>
+                  <Link to="/residential-cleaning-toronto">residential cleaning in Toronto</Link>
+                </li>
+              </ul>
+              <p className="mb-0">
+                Ready to plan your service?{" "}
+                <Link to="/?service=Commercial+Cleaning">request a cleaning quote in Toronto</Link>.
+              </p>
+            </section>
           </Col>
         </Row>
       </Container>

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -227,9 +227,15 @@ const ProductsAndServices = () => {
 
           <div className="mt-4 text-cleanar-color">
             <h3 className="h5 text-bold">Toronto Service Pages</h3>
+            <p className="mb-2">
+              Browse our dedicated location pages to compare cleaning options by property type and project scope.
+            </p>
             <ul className="mb-0">
-              <li><Link to="/deep-cleaning-toronto">Deep Cleaning Toronto</Link></li>
-              <li><Link to="/move-in-move-out-cleaning-toronto">Move-In/Move-Out Cleaning Toronto</Link></li>
+              <li><Link to="/residential-cleaning-toronto">residential cleaning in Toronto</Link></li>
+              <li><Link to="/commercial-cleaning-toronto">commercial cleaning in Toronto</Link></li>
+              <li><Link to="/deep-cleaning-toronto">deep cleaning in Toronto</Link></li>
+              <li><Link to="/move-in-move-out-cleaning-toronto">move-in and move-out cleaning in Toronto</Link></li>
+              <li><Link to="/carpet-upholstery-cleaning-toronto">carpet and upholstery cleaning in Toronto</Link></li>
             </ul>
           </div>
         </div>

--- a/client/src/components/Pages/Navigation/TorontoServicePage.jsx
+++ b/client/src/components/Pages/Navigation/TorontoServicePage.jsx
@@ -14,9 +14,9 @@ const SERVICE_PAGES = {
     ctaLabel: "Get a Residential Cleaning Quote",
     quoteQuery: "Residential+Cleaning",
     related: [
-      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
-      { to: "/move-in-move-out-cleaning-toronto", label: "Move-In/Move-Out Cleaning" },
-      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+      { to: "/deep-cleaning-toronto", label: "deep cleaning in Toronto" },
+      { to: "/move-in-move-out-cleaning-toronto", label: "move-in and move-out cleaning in Toronto" },
+      { to: "/commercial-cleaning-toronto", label: "commercial cleaning in Toronto" },
     ],
     faqs: [
       {
@@ -45,9 +45,9 @@ const SERVICE_PAGES = {
     ctaLabel: "Request a Commercial Cleaning Plan",
     quoteQuery: "Commercial+Cleaning",
     related: [
-      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
-      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
-      { to: "/carpet-upholstery-cleaning-toronto", label: "Carpet & Upholstery Cleaning" },
+      { to: "/residential-cleaning-toronto", label: "residential cleaning in Toronto" },
+      { to: "/deep-cleaning-toronto", label: "deep cleaning in Toronto" },
+      { to: "/carpet-upholstery-cleaning-toronto", label: "carpet and upholstery cleaning in Toronto" },
     ],
     faqs: [
       {
@@ -76,9 +76,9 @@ const SERVICE_PAGES = {
     ctaLabel: "Book Deep Cleaning in Toronto",
     quoteQuery: "Deep+Cleaning",
     related: [
-      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
-      { to: "/move-in-move-out-cleaning-toronto", label: "Move-In/Move-Out Cleaning" },
-      { to: "/carpet-upholstery-cleaning-toronto", label: "Carpet & Upholstery Cleaning" },
+      { to: "/residential-cleaning-toronto", label: "residential cleaning in Toronto" },
+      { to: "/move-in-move-out-cleaning-toronto", label: "move-in and move-out cleaning in Toronto" },
+      { to: "/carpet-upholstery-cleaning-toronto", label: "carpet and upholstery cleaning in Toronto" },
     ],
     faqs: [
       {
@@ -107,9 +107,9 @@ const SERVICE_PAGES = {
     ctaLabel: "Schedule Move-In/Move-Out Cleaning",
     quoteQuery: "Move+In+Move+Out+Cleaning",
     related: [
-      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
-      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
-      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+      { to: "/deep-cleaning-toronto", label: "deep cleaning in Toronto" },
+      { to: "/residential-cleaning-toronto", label: "residential cleaning in Toronto" },
+      { to: "/commercial-cleaning-toronto", label: "commercial cleaning in Toronto" },
     ],
     faqs: [
       {
@@ -138,9 +138,9 @@ const SERVICE_PAGES = {
     ctaLabel: "Request Carpet & Upholstery Cleaning",
     quoteQuery: "Carpet+And+Upholstery",
     related: [
-      { to: "/deep-cleaning-toronto", label: "Deep Cleaning Toronto" },
-      { to: "/residential-cleaning-toronto", label: "Residential Cleaning Toronto" },
-      { to: "/commercial-cleaning-toronto", label: "Commercial Cleaning Toronto" },
+      { to: "/deep-cleaning-toronto", label: "deep cleaning in Toronto" },
+      { to: "/residential-cleaning-toronto", label: "residential cleaning in Toronto" },
+      { to: "/commercial-cleaning-toronto", label: "commercial cleaning in Toronto" },
     ],
     faqs: [
       {
@@ -206,6 +206,10 @@ const TorontoServiceTemplate = ({ serviceKey }) => {
             </li>
           ))}
         </ul>
+        <p className="mt-3 mb-0">
+          Need to compare options?{" "}
+          <Link to="/products-and-services">Return to the Toronto services hub</Link>.
+        </p>
       </section>
     </section>
   );

--- a/client/src/views/Index.jsx
+++ b/client/src/views/Index.jsx
@@ -68,6 +68,20 @@ function Index() {
 
       {/* BODY */}
       <div className="container">
+        <section className="my-4" aria-label="Toronto cleaning services links">
+          <h2 className="h4 text-bold primary-color mb-2">Popular cleaning services in Toronto</h2>
+          <p className="text-muted mb-2">
+            Explore our local landing pages for homes and businesses across Toronto and the GTA.
+          </p>
+          <ul className="mb-0">
+            <li><Link to="/residential-cleaning-toronto">residential cleaning in Toronto</Link></li>
+            <li><Link to="/commercial-cleaning-toronto">commercial cleaning in Toronto</Link></li>
+            <li><Link to="/deep-cleaning-toronto">deep cleaning in Toronto</Link></li>
+            <li><Link to="/move-in-move-out-cleaning-toronto">move-in and move-out cleaning in Toronto</Link></li>
+            <li><Link to="/carpet-upholstery-cleaning-toronto">carpet and upholstery cleaning in Toronto</Link></li>
+          </ul>
+        </section>
+
         <Row>
           <Col xs="12" md="12" className="p-0" id="quote-section">
             <QuoteRequest initialData={{}} />


### PR DESCRIPTION
### Motivation
- Improve internal crawlability and local SEO by adding natural, local-intent anchor text that points from marketing pages and blog content to each Toronto service landing page.
- Surface convenient quote routes from blog content so users can convert directly from relevant articles and listings.

### Description
- Added a crawlable list of Toronto service links to the homepage in `Index.jsx` with local-intent anchor text (e.g., "deep cleaning in Toronto").
- Expanded the services hub (`ProductsAndServices.jsx`) to include crawlable text links to all dedicated Toronto service pages using natural local-intent phrasing.
- Updated Toronto service templates (`TorontoServicePage.jsx`) to use local-intent labels for "related services" links and added a text link back to the services hub.
- Enhanced blog listing (`BlogLandingPage.jsx`) and blog articles (`CleanARJoinsISSACanada.jsx`, `CleanARJoinsCQCC.jsx`) to include contextual links to matching service pages and a quote CTA route per post.

### Testing
- Ran `npm --prefix client run build`, which completed successfully and produced prerendered marketing routes for the new Toronto service pages.
- The production build (`vite build`) finished without errors and generated the expected dist artifacts (build warnings only for large chunks, no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df05791de48329980e91ab56d6f137)