### PR TITLE
Fix repeated PWA “new content” refresh prompt

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -51,10 +51,10 @@ const DeepCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigat
 const MoveInMoveOutCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.MoveInMoveOutCleaningTorontoPage })));
 const CarpetUpholsteryCleaningTorontoPage = lazy(() => import("/src/components/Pages/Navigation/TorontoServicePage.jsx").then((module) => ({ default: module.CarpetUpholsteryCleaningTorontoPage })));
 
-registerSW({
+const updateSW = registerSW({
   onNeedRefresh() {
-    if (confirm("New content available. Reload?")) {
-      window.location.reload();
+    if (window.confirm("New content available. Reload?")) {
+      updateSW(true);
     }
   },
   onOfflineReady() {


### PR DESCRIPTION
### Motivation
- The app repeatedly showed the "New content available. Reload?" prompt and could loop after the user confirmed, indicating the service worker update flow wasn't being triggered correctly. 
- The change aims to activate the waiting service worker instead of forcing a hard reload so the update completes and the prompt stops reappearing.

### Description
- Updated PWA registration in `client/src/index.jsx` to store the updater returned from `registerSW` in `updateSW` and use it to trigger the update. 
- Replaced the previous `window.location.reload()` path with a call to `updateSW(true)` after user confirmation via `window.confirm(...)`, while leaving `onOfflineReady` behavior unchanged.

### Testing
- Ran the production build with `npm --prefix client run build`, which completed successfully. 
- The build generated the PWA artifacts including `dist/sw.js` and the precache manifest, indicating the service worker was built and included in the output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df094ac5a88329b14a3f3d62993f49)