### PR TITLE
Fix PWA refresh loop by suppressing repeated prompt for same waiting service worker

### DIFF
--- a/client/src/pwa.js
+++ b/client/src/pwa.js
@@ -3,6 +3,7 @@ import { registerSW } from 'virtual:pwa-register';
 let needRefresh = false;
 let swUpdater;
 const listeners = new Set();
+const DISMISSED_WAITING_SW_KEY = 'dismissedWaitingServiceWorker';
 
 const notifyListeners = () => {
   listeners.forEach((listener) => listener(needRefresh));
@@ -11,6 +12,18 @@ const notifyListeners = () => {
 const setNeedRefresh = (value) => {
   needRefresh = value;
   notifyListeners();
+};
+
+const getWaitingServiceWorkerUrl = async () => {
+  if (!('serviceWorker' in navigator)) return null;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    return registration?.waiting?.scriptURL ?? null;
+  } catch (error) {
+    console.warn('Unable to inspect waiting service worker', error);
+    return null;
+  }
 };
 
 export const subscribeNeedRefresh = (listener) => {
@@ -22,19 +35,34 @@ export const subscribeNeedRefresh = (listener) => {
   };
 };
 
-export const dismissRefreshPrompt = () => {
+export const dismissRefreshPrompt = async () => {
+  const waitingScriptUrl = await getWaitingServiceWorkerUrl();
+
+  if (waitingScriptUrl) {
+    localStorage.setItem(DISMISSED_WAITING_SW_KEY, waitingScriptUrl);
+  }
+
   setNeedRefresh(false);
 };
 
 export const applyServiceWorkerUpdate = () => {
   if (!swUpdater) return;
 
+  localStorage.removeItem(DISMISSED_WAITING_SW_KEY);
   setNeedRefresh(false);
   swUpdater(true);
 };
 
 swUpdater = registerSW({
-  onNeedRefresh() {
+  async onNeedRefresh() {
+    const waitingScriptUrl = await getWaitingServiceWorkerUrl();
+    const dismissedWaitingScriptUrl = localStorage.getItem(DISMISSED_WAITING_SW_KEY);
+
+    if (waitingScriptUrl && waitingScriptUrl === dismissedWaitingScriptUrl) {
+      setNeedRefresh(false);
+      return;
+    }
+
     setNeedRefresh(true);
   },
   onOfflineReady() {


### PR DESCRIPTION
### Motivation
- The app uses prompt-based updates (`registerType: "prompt"` with `skipWaiting: false`) and the previous `dismissRefreshPrompt()` only cleared in-memory state, so the same waiting service worker repeatedly retriggered `onNeedRefresh` across reloads and caused a refresh prompt loop.
- The change keeps a single prompt-driven update strategy and avoids any automatic update/reload behavior while preventing redundant prompts for the same pending worker.

### Description
- Persist a dismissal marker in `localStorage` under `dismissedWaitingServiceWorker` to remember which waiting service worker the user dismissed.
- Add `getWaitingServiceWorkerUrl()` which inspects `navigator.serviceWorker.getRegistration()` and returns the `registration.waiting.scriptURL` safely.
- Make `dismissRefreshPrompt()` store the waiting SW URL (if present) and make `onNeedRefresh` async and compare the waiting SW URL to the dismissed marker to suppress re-showing the prompt for the same worker.
- Remove the dismissed marker when the user explicitly applies the update, and keep `swUpdater(true)` as a user-driven action (no automatic calls introduced).

### Testing
- Searched the codebase for service-worker / update hooks to ensure only one registration path and no mixed strategies (`registerSW`, `navigator.serviceWorker`, `registration.update`, `window.location.reload`, `updateServiceWorker` etc.).
- Built the client with `npm --prefix client run build` and the build completed successfully.
- Verified the update flow remains manual (prompt-based) and no automatic `registration.update()` / `updateServiceWorker()` / `window.location.reload()` calls were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df798a771c832982c3583bf00258c6)