### PR TITLE
Centralize auth fetch and enforce authentication/authorization on client and server

### DIFF
--- a/client/src/components/API/customerApi.jsx
+++ b/client/src/components/API/customerApi.jsx
@@ -1,15 +1,17 @@
+import { authFetch } from '/src/utils/authFetch';
+
 export const getCustomers = async () => {
-  const res = await fetch('/api/customers');
+  const res = await authFetch('/api/customers');
   return res.json();
 };
 export const getCustomerById = async (id) => {
-  const res = await fetch(`/api/customers/${id}`);
+  const res = await authFetch(`/api/customers/${id}`);
   if (!res.ok) throw new Error('Customer not found');
   return res.json();
 };
 
 export const createCustomer = async (data) => {
-  const res = await fetch('/api/customers', {
+  const res = await authFetch('/api/customers', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
@@ -19,13 +21,13 @@ export const createCustomer = async (data) => {
 };
 
 export const deleteCustomer = async (id) => {
-  const res = await fetch(`/api/customers/${id}`, { method: 'DELETE' });
+  const res = await authFetch(`/api/customers/${id}`, { method: 'DELETE' });
   if (!res.ok) throw new Error('Failed to delete customer');
   return res.json();
 };
 
 export const updateCustomer = async (id, data) => {
-  const res = await fetch(`/api/customers/${id}/`, {
+  const res = await authFetch(`/api/customers/${id}/`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)

--- a/client/src/components/Pages/Dashboards/DailyReport.jsx
+++ b/client/src/components/Pages/Dashboards/DailyReport.jsx
@@ -1,3 +1,4 @@
+import { authFetch } from "/src/utils/authFetch";
 // src/components/Pages/Management/DailyReport.jsx
 import React, { useEffect, useMemo, useState } from "react";
 import { Card, Row, Col, Spinner, Badge, Form } from "react-bootstrap";
@@ -49,7 +50,7 @@ export default function DailyReport() {
           date,
           excludeBots: String(excludeBots),
         });
-        const res = await fetch(`/api/visitors/daily-report?${qs.toString()}`, {
+        const res = await authFetch(`/api/visitors/daily-report?${qs.toString()}`, {
           cache: "no-store",
         });
         if (!res.ok) throw new Error("Failed to fetch daily report");

--- a/client/src/components/Pages/Dashboards/WeeklyReport.jsx
+++ b/client/src/components/Pages/Dashboards/WeeklyReport.jsx
@@ -1,3 +1,4 @@
+import { authFetch } from "/src/utils/authFetch";
 // src/components/Pages/Management/WeeklyReport.jsx
 import React, { useEffect, useMemo, useState } from "react";
 import { Card, Row, Col, Spinner, Badge, Form } from "react-bootstrap";
@@ -47,7 +48,7 @@ export default function WeeklyReport() {
           end,
           excludeBots: String(excludeBots),
         });
-        const res = await fetch(`/api/visitors/weekly-reporting?${qs.toString()}`, {
+        const res = await authFetch(`/api/visitors/weekly-reporting?${qs.toString()}`, {
           cache: "no-store",
         });
         if (!res.ok) throw new Error("Failed to fetch weekly report");

--- a/client/src/components/Pages/Management/BookingCalendar.jsx
+++ b/client/src/components/Pages/Management/BookingCalendar.jsx
@@ -14,6 +14,7 @@ import {
 } from "react-bootstrap";
 import "/src/assets/css/bookingcalendar.css";
 import Auth from "/src/utils/auth";
+import { authFetch } from "/src/utils/authFetch";
 import BookingForm from "../Booking/BookingForm";
 import GenerateInvoiceModal from "../Booking/GenerateInvoiceModal";
 import BookingActions from "../Booking/BookingActions";
@@ -83,8 +84,8 @@ const BookingCalendar = ({
       setDigestMsg("");
       setDigestErr("");
 
-      // const res = await fetch("/api/email/admin-upcoming-bookings-digest", {
-      const res = await fetch("/api/email/upcoming-bookings", {
+      // const res = await authFetch("/api/email/admin-upcoming-bookings-digest", {
+      const res = await authFetch("/api/email/upcoming-bookings", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ days: Number(digestDays) || 7 }),
@@ -117,7 +118,7 @@ const BookingCalendar = ({
         // If not in current list (e.g. different month / filtered),
         // fetch directly by id so we can still open the modal.
         if (!bookingToOpen) {
-          const res = await fetch(`/api/bookings/${incomingBookingId}`);
+          const res = await authFetch(`/api/bookings/${incomingBookingId}`);
           if (res.ok) bookingToOpen = await res.json();
         }
 
@@ -214,7 +215,7 @@ const BookingCalendar = ({
       try {
         // ✅ Endpoint you should add (or already have):
         // GET /api/invoices/by-booking/:bookingId
-        const res = await fetch(`/api/invoices/by-booking/${selectedBooking._id}`);
+        const res = await authFetch(`/api/invoices/by-booking/${selectedBooking._id}`);
         if (!res.ok) {
           setInvoiceInfo(null);
           return;
@@ -279,7 +280,7 @@ const BookingCalendar = ({
   //   };
 
   //   try {
-  //     const res = await fetch(
+  //     const res = await authFetch(
   //       `/api/bookings/${selectedBooking._id}/update`,
   //       {
   //         method: "PUT",
@@ -387,7 +388,7 @@ const BookingCalendar = ({
 
     try {
       setLoading(true);
-      const res = await fetch(
+      const res = await authFetch(
         `/api/bookings/${selectedBooking._id}/update`,
         {
           method: "PUT",
@@ -539,7 +540,7 @@ const BookingCalendar = ({
     };
 
     try {
-      const res = await fetch(`/api/bookings/${bookingId}/confirm`, {
+      const res = await authFetch(`/api/bookings/${bookingId}/confirm`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -577,7 +578,7 @@ const BookingCalendar = ({
     try {
       setLoading(true);
 
-      const res = await fetch(
+      const res = await authFetch(
         `/api/bookings/${selectedBooking._id}/update-date`,
         {
           method: "PUT",
@@ -616,7 +617,7 @@ const BookingCalendar = ({
 
   // const fetchBookings = async () => {
   //   try {
-  //     const res = await fetch('/api/bookings');
+  //     const res = await authFetch('/api/bookings');
   //     if (!res.ok) throw new Error('Failed to fetch bookings');
   //     const data = await res.json();
   //     // filter out data that is hidden
@@ -635,7 +636,7 @@ const BookingCalendar = ({
     if (!window.confirm('Are you sure you want to cancel this booking?')) return;
     // return async () => {
     try {
-      const res = await fetch(`/api/bookings/${bookingId}/cancel`, {
+      const res = await authFetch(`/api/bookings/${bookingId}/cancel`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'cancelled', updatedBy: Auth.getProfile().data._id }) // Assuming you have user authentication
@@ -655,7 +656,7 @@ const BookingCalendar = ({
     }
     if (!window.confirm('Are you sure you want to pend this booking?')) return;
     try {
-      const res = await fetch(`/api/bookings/${bookingId}/pending`, {
+      const res = await authFetch(`/api/bookings/${bookingId}/pending`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'pending', updatedBy: Auth.getProfile().data._id }) // Assuming you have user authentication
@@ -671,7 +672,7 @@ const BookingCalendar = ({
     if (!window.confirm('Are you sure you want to delete this booking?')) return;
 
     try {
-      const res = await fetch(`/api/bookings/${bookingId}`, { method: 'DELETE' });
+      const res = await authFetch(`/api/bookings/${bookingId}`, { method: 'DELETE' });
       if (!res.ok) throw new Error('Failed to delete');
       fetchBookings();
     } catch (err) {
@@ -690,7 +691,7 @@ const BookingCalendar = ({
     }
     if (!window.confirm('Are you sure you want to mark this booking as completed?')) return;
     try {
-      const res = await fetch(`/api/bookings/${bookingId}/complete`, {
+      const res = await authFetch(`/api/bookings/${bookingId}/complete`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: 'completed', updatedBy: Auth.getProfile().data._id }) // Assuming you have user authentication
@@ -709,7 +710,7 @@ const BookingCalendar = ({
     }
     if (!window.confirm('Are you sure you want to hide this booking?')) return;
     try {
-      const res = await fetch(`/api/bookings/${bookingId}/hide`, {
+      const res = await authFetch(`/api/bookings/${bookingId}/hide`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ hidden: true, updatedBy: Auth.getProfile().data._id }) // Assuming you have user authentication

--- a/client/src/components/Pages/Management/BookingDashboard.jsx
+++ b/client/src/components/Pages/Management/BookingDashboard.jsx
@@ -19,6 +19,7 @@ import {
   CartesianGrid,
 } from 'recharts';
 import BookingCalendar from '/src/components/Pages/Management/BookingCalendar';
+import { authFetch } from '/src/utils/authFetch';
 
 function normalizeStatus(status) {
   return (status || '').toLowerCase();
@@ -38,7 +39,7 @@ export default function BookingDashboard() {
 
   const fetchBookings = async () => {
     try {
-      const res = await fetch('/api/bookings');
+      const res = await authFetch('/api/bookings');
       if (!res.ok) throw new Error('Failed to fetch bookings');
       const data = await res.json();
       // filter out data that is hidden
@@ -73,7 +74,7 @@ export default function BookingDashboard() {
   useEffect(() => {
   const fetchCustomers = async () => {
     try {
-      const res = await fetch('/api/customers');
+      const res = await authFetch('/api/customers');
       if (!res.ok) throw new Error('Failed to fetch customers');
       const data = await res.json();
       setCustomers(data);

--- a/client/src/components/Pages/Management/CustomerStatsCard.jsx
+++ b/client/src/components/Pages/Management/CustomerStatsCard.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Card, Row, Col, Spinner } from "react-bootstrap";
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { authFetch } from "/src/utils/authFetch";
 
 const COLORS = ["#00C49F", "#FFBB28", "#FF8042"];
 
@@ -10,7 +11,7 @@ const CustomerStatsCard = () => {
 
   const fetchStats = async () => {
     try {
-      const res = await fetch("/api/customers/stats");
+      const res = await authFetch("/api/customers/stats");
       const data = await res.json();
       setStats(data.map(item => ({
         name: item._id,

--- a/client/src/components/Pages/Management/EventsDashboard.jsx
+++ b/client/src/components/Pages/Management/EventsDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Row, Col, Card, Spinner, Badge, Button, Form, Collapse, Table } from "react-bootstrap";
 import { FaBolt, FaCalendarDay, FaMousePointer, FaPaperPlane } from "react-icons/fa";
+import { authFetch } from "/src/utils/authFetch";
 
 /**
  * EventsDashboard.jsx
@@ -298,7 +299,7 @@ const EventsDashboard = () => {
     setReportStatus(null);
 
     try {
-      const res = await fetch("/api/admin-reports/send-daily-events", {
+      const res = await authFetch("/api/admin-reports/send-daily-events", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
       });
@@ -340,7 +341,7 @@ const EventsDashboard = () => {
         // IMPORTANT: include bots in raw fetch; we filter at event-level
         params.set("excludeBots", "false");
 
-        const res = await fetch(`/api/visitors/logs?${params.toString()}`);
+        const res = await authFetch(`/api/visitors/logs?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch logs");
 
         const data = await res.json();

--- a/client/src/components/Pages/Management/LogDashboard.jsx
+++ b/client/src/components/Pages/Management/LogDashboard.jsx
@@ -1,3 +1,4 @@
+import { authFetch } from "/src/utils/authFetch";
 // LogDashboard.jsx (DROP-IN)
 // Server-driven analytics (weekly-reporting) + server-driven log table (logs)
 // Uses MiniBars chart (no chart libs). Keeps your FilterBar + LogTable + Pagination components.
@@ -295,7 +296,7 @@ const LogDashboard = () => {
     setReportStatus(null);
 
     try {
-      const res = await fetch("/api/admin-reports/send-daily-events", {
+      const res = await authFetch("/api/admin-reports/send-daily-events", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         // optional override:
@@ -379,7 +380,7 @@ const LogDashboard = () => {
         params.set("pageNum", "1");
         params.set("sort", "desc");
 
-        const res = await fetch(`/api/visitors/logs?${params.toString()}`);
+        const res = await authFetch(`/api/visitors/logs?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch logs (options sample)");
         const data = await res.json();
 
@@ -444,7 +445,7 @@ const LogDashboard = () => {
         // weekly-reporting doesn't use start; keep request clean
         params.delete("start");
 
-        const res = await fetch(`/api/visitors/weekly-reporting?${params.toString()}`);
+        const res = await authFetch(`/api/visitors/weekly-reporting?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch weekly report");
         const data = await res.json();
 
@@ -499,7 +500,7 @@ const LogDashboard = () => {
         // include numeric filters if you want them server-side later.
         // For now, keep them client-side on the returned page only (lightweight).
         // If you want full accuracy, add these to backend match and remove client filtering.
-        const res = await fetch(`/api/visitors/logs?${params.toString()}`);
+        const res = await authFetch(`/api/visitors/logs?${params.toString()}`);
         if (!res.ok) throw new Error("Failed to fetch logs");
         const data = await res.json();
 

--- a/client/src/components/Pages/Management/ManageUser.jsx
+++ b/client/src/components/Pages/Management/ManageUser.jsx
@@ -120,7 +120,7 @@ const ManageUser = () => {
             try {
                 // Users
                 // const userData = await apiFetch('/api/admin/users'); // not using as i currently have the path routes blocked at the front-end
-                const userData = await apiFetch('/api/users');
+                const userData = await apiFetch('/api/admin/users');
                 setUsers(userData);
 
                 // Roles (optional, if you have this endpoint)
@@ -232,7 +232,7 @@ const ManageUser = () => {
             };
 
             // const updated = await apiFetch(`/api/admin/users/${editedUser._id}`, {
-             const updated = await apiFetch(`/api/users/${editedUser._id}`, {
+             const updated = await apiFetch(`/api/admin/users/${editedUser._id}`, {
                 method: 'PUT',
                 body: JSON.stringify(body),
             });
@@ -264,7 +264,7 @@ const ManageUser = () => {
         setSuccess('');
         try {
             // await apiFetch(`/api/admin/users/${userId}`, {
-            await apiFetch(`/api/users/${userId}`, {
+            await apiFetch(`/api/admin/users/${userId}`, {
                 method: 'DELETE',
             });
             setUsers((prev) => prev.filter((u) => u._id !== userId));
@@ -311,7 +311,7 @@ const ManageUser = () => {
 
         try {
             // const newUser = await apiFetch('/api/admin/users', {
-            const newUser = await apiFetch('/api/users', {
+            const newUser = await apiFetch('/api/admin/users', {
                 method: 'POST',
                 body: JSON.stringify({
                     firstName,

--- a/client/src/components/Pages/Management/ProtectedRoute.jsx
+++ b/client/src/components/Pages/Management/ProtectedRoute.jsx
@@ -2,10 +2,21 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import Auth from "/src/utils/auth"; // Adjust the path based on your project structure
 
-const ProtectedRoute = ({ element }) => {
+const ProtectedRoute = ({ element, requireAdmin = false }) => {
   const isAuthenticated = Auth.loggedIn();
+  const profile = Auth.getProfile()?.data;
+  const roleNames = Array.isArray(profile?.roles) ? profile.roles : [];
+  const isAdmin = !!profile?.adminFlag || roleNames.includes('admin');
 
-  return isAuthenticated ? element : <Navigate to="/login-page" replace />;
+  if (!isAuthenticated) {
+    return <Navigate to="/login-signup" replace />;
+  }
+
+  if (requireAdmin && !isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return element;
 };
 
 export default ProtectedRoute;

--- a/client/src/components/Pages/Management/ReportDownloadButton.jsx
+++ b/client/src/components/Pages/Management/ReportDownloadButton.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Button } from 'react-bootstrap';
+import { authFetch } from '/src/utils/authFetch';
 
 const ReportDownloadButton = () => {
   const handleDownload = async () => {
     try {
-      const res = await fetch('/api/email/weekly-report', {
+      const res = await authFetch('/api/email/weekly-report', {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -130,7 +130,7 @@ const App = () => {
               <Route path="/" element={<Index />} />
               <Route path="/index" element={<IndexCompatibilityRedirect />} />
               <Route path="/profile-page" element={<ProtectedRoute element={<ProfilePage />} />} />
-              <Route path="/notification-management" element={<ProtectedRoute element={<NotificationAdminPage />} />} />
+              <Route path="/notification-management" element={<ProtectedRoute requireAdmin element={<NotificationAdminPage />} />} />
               {/* <Route path="/manage-categories" element={<ProtectedRoute element={<ManageCategories />} />} /> */}
               {/* <Route path="/manage-service" element={<ProtectedRoute element={<ManageService />} />} /> */}
               {/* <Route path="/manage-product" element={<ProtectedRoute element={<ManageProduct />} />} /> */}
@@ -156,7 +156,7 @@ const App = () => {
                 path="/blog/cleanar-joins-cqcc"
                 element={<CleanARJoinsCQCC />}
               />
-              <Route path="/admin" element={<AdminManagementLayout />}>
+              <Route path="/admin" element={<ProtectedRoute requireAdmin element={<AdminManagementLayout />} />}>
                 <Route index element={<Navigate to="booking" replace />} />
                 <Route path="accounting" element={<AccountingTabbedView />} />
                 <Route path="booking" element={<BookingTabbedView />} />

--- a/client/src/utils/auth-updated.jsx
+++ b/client/src/utils/auth-updated.jsx
@@ -2,6 +2,13 @@ import { jwtDecode } from 'jwt-decode';
 
 class AuthService {
   isLoggingOut = false;
+  getCookie(name) {
+    if (typeof document === 'undefined') return '';
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) return parts.pop().split(';').shift() || '';
+    return '';
+  }
   getProfile() {
     // return jwtDecode(this.getToken());
     const token = this.getToken();
@@ -92,9 +99,11 @@ class AuthService {
   async logout() {
         this.isLoggingOut = true;
     // Clear user token and profile data from localStorage
+    const csrfToken = this.getCookie('csrfToken');
 
     await fetch("/api/users/logout", {
       method: "POST",
+      headers: csrfToken ? { 'x-csrf-token': csrfToken } : {},
       credentials: "include",
     });
       this.isLoggingOut = false;
@@ -107,8 +116,10 @@ class AuthService {
   }
   async refreshToken() {
     try {
+      const csrfToken = this.getCookie('csrfToken');
       const res = await fetch("/api/users/refresh", {
         method: "POST",
+        headers: csrfToken ? { 'x-csrf-token': csrfToken } : {},
         credentials: "include",
       });
 

--- a/client/src/utils/authFetch.js
+++ b/client/src/utils/authFetch.js
@@ -1,0 +1,16 @@
+import Auth from "/src/utils/auth";
+
+export const withAuthHeaders = (headers = {}) => {
+  const token = Auth.getToken();
+  return {
+    ...headers,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+};
+
+export const authFetch = (url, options = {}) => {
+  return fetch(url, {
+    ...options,
+    headers: withAuthHeaders(options.headers),
+  });
+};

--- a/server/controllers/userControllers.js
+++ b/server/controllers/userControllers.js
@@ -3,6 +3,7 @@ const Customer = require('../models/Customer');
 const { signToken } = require('../utils/auth');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
+const crypto = require('crypto');
 
 
 const userControllers = {
@@ -94,6 +95,7 @@ const userControllers = {
         }
         const token = signToken(dbUserData, process.env.ACCESS_SECRET_KEY, process.env.ACCESS_KEY_EXPIRATION || "2h");
         const refreshToken = jwt.sign({ id: dbUserData._id }, process.env.REFRESH_SECRET_KEY, { expiresIn: process.env.REFRESH_KEY_EXPIRATION || '30d' });
+        const csrfToken = crypto.randomBytes(32).toString('hex');
         dbUserData.refreshToken = refreshToken;
         await dbUserData.save();
 
@@ -114,6 +116,12 @@ const userControllers = {
         };
         res.cookie("refreshToken", refreshToken, {
             httpOnly: true,
+            secure: true,
+            sameSite: "Strict",
+            maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+        });
+        res.cookie("csrfToken", csrfToken, {
+            httpOnly: false,
             secure: true,
             sameSite: "Strict",
             maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
@@ -142,6 +150,11 @@ const userControllers = {
 
         res.clearCookie("refreshToken", {
             httpOnly: true,
+            secure: true,
+            sameSite: "Strict",
+        });
+        res.clearCookie("csrfToken", {
+            httpOnly: false,
             secure: true,
             sameSite: "Strict",
         });

--- a/server/middleware/rateLimiters.js
+++ b/server/middleware/rateLimiters.js
@@ -1,0 +1,20 @@
+const rateLimit = require('express-rate-limit');
+
+const authRouteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 300,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const adminRouteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+module.exports = {
+  authRouteLimiter,
+  adminRouteLimiter,
+};

--- a/server/middleware/requireAdminFlag.js
+++ b/server/middleware/requireAdminFlag.js
@@ -1,0 +1,13 @@
+const requireAdminFlag = (req, res, next) => {
+  if (!req.user || !req.user._id) {
+    return res.status(401).json({ message: 'Not authenticated' });
+  }
+
+  if (!req.user.adminFlag) {
+    return res.status(403).json({ message: 'Not authorized' });
+  }
+
+  return next();
+};
+
+module.exports = requireAdminFlag;

--- a/server/middleware/validateCsrfToken.js
+++ b/server/middleware/validateCsrfToken.js
@@ -1,0 +1,12 @@
+const validateCsrfToken = (req, res, next) => {
+  const csrfCookie = req.cookies?.csrfToken;
+  const csrfHeader = req.headers['x-csrf-token'];
+
+  if (!csrfCookie || !csrfHeader || csrfCookie !== csrfHeader) {
+    return res.status(403).json({ message: 'Invalid CSRF token' });
+  }
+
+  return next();
+};
+
+module.exports = validateCsrfToken;

--- a/server/routes/api/adminReportsRoutes.js
+++ b/server/routes/api/adminReportsRoutes.js
@@ -1,6 +1,11 @@
 const router = require("express").Router();
 const cron = require("node-cron");
 const { sendDailyEventsReportEmail } = require("../../controllers/eventsReportController");
+const { authMiddleware } = require("../../utils/auth");
+const requireAdminFlag = require("../../middleware/requireAdminFlag");
+
+router.use(authMiddleware);
+router.use(requireAdminFlag);
 
 // Manually trigger (admin)
 router.post("/send-daily-events", async (req, res) => {

--- a/server/routes/api/adminReportsRoutes.js
+++ b/server/routes/api/adminReportsRoutes.js
@@ -3,7 +3,9 @@ const cron = require("node-cron");
 const { sendDailyEventsReportEmail } = require("../../controllers/eventsReportController");
 const { authMiddleware } = require("../../utils/auth");
 const requireAdminFlag = require("../../middleware/requireAdminFlag");
+const { adminRouteLimiter } = require("../../middleware/rateLimiters");
 
+router.use(adminRouteLimiter);
 router.use(authMiddleware);
 router.use(requireAdminFlag);
 

--- a/server/routes/api/adminUserRoutes.js
+++ b/server/routes/api/adminUserRoutes.js
@@ -1,7 +1,7 @@
 // routes/adminUserRoutes.js
 const router = require('express').Router();
-// const authMiddleware = require('../middleware/authMiddleware');
-const requireRole = require('../../middleware/requireRole');
+const { authMiddleware } = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
 const {
     getUsers,
     getRoles,
@@ -11,8 +11,8 @@ const {
 } = require('../../controllers/adminUserController');
 
 // All routes in this file require authentication + admin role
-// router.use(authMiddleware);
-router.use(requireRole('admin')); // or 'super_admin' if you add that later
+router.use(authMiddleware);
+router.use(requireAdminFlag); // or 'super_admin' if you add that later
 
 // GET /api/admin/users
 router.get('/users', getUsers);

--- a/server/routes/api/adminUserRoutes.js
+++ b/server/routes/api/adminUserRoutes.js
@@ -2,6 +2,7 @@
 const router = require('express').Router();
 const { authMiddleware } = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { adminRouteLimiter } = require('../../middleware/rateLimiters');
 const {
     getUsers,
     getRoles,
@@ -11,6 +12,7 @@ const {
 } = require('../../controllers/adminUserController');
 
 // All routes in this file require authentication + admin role
+router.use(adminRouteLimiter);
 router.use(authMiddleware);
 router.use(requireAdminFlag); // or 'super_admin' if you add that later
 

--- a/server/routes/api/bookingRoutes.js
+++ b/server/routes/api/bookingRoutes.js
@@ -5,6 +5,7 @@ const Booking = require('../../models/Booking');
 const NotificationService = require('../../services/NotificationService');
 const { authMiddleware } = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { adminRouteLimiter } = require('../../middleware/rateLimiters');
 const { createBooking, getBookings, deleteBooking, completeBooking, hideBooking, sendScheduledReminder, sendScheduledConfirmationEmail, confirmBooking, cancelBooking, pendBookingById,
   updateBookingDate,
   submitNewDateRequest,
@@ -15,16 +16,16 @@ const { createBooking, getBookings, deleteBooking, completeBooking, hideBooking,
 
 router.post('/', createBooking);
 router.post('/request', submitNewBookingRequest);
-router.get('/', authMiddleware, requireAdminFlag, getBookings);
-router.delete('/:id', authMiddleware, requireAdminFlag, deleteBooking);
-router.put('/:id/update-date', authMiddleware, requireAdminFlag, updateBookingDate);
-router.put('/:id/complete', authMiddleware, requireAdminFlag, completeBooking);
-router.put('/:id/hide', authMiddleware, requireAdminFlag, hideBooking);
-router.put('/:id/confirm', authMiddleware, requireAdminFlag, confirmBooking);
-router.put('/:id/cancel', authMiddleware, requireAdminFlag, cancelBooking);
-router.put('/:id/pending', authMiddleware, requireAdminFlag, pendBookingById);
-router.put('/:id/request-change', authMiddleware, requireAdminFlag, submitNewDateRequest);
-router.put('/:id/update', authMiddleware, requireAdminFlag, updateBooking);
+router.get('/', adminRouteLimiter, authMiddleware, requireAdminFlag, getBookings);
+router.delete('/:id', adminRouteLimiter, authMiddleware, requireAdminFlag, deleteBooking);
+router.put('/:id/update-date', adminRouteLimiter, authMiddleware, requireAdminFlag, updateBookingDate);
+router.put('/:id/complete', adminRouteLimiter, authMiddleware, requireAdminFlag, completeBooking);
+router.put('/:id/hide', adminRouteLimiter, authMiddleware, requireAdminFlag, hideBooking);
+router.put('/:id/confirm', adminRouteLimiter, authMiddleware, requireAdminFlag, confirmBooking);
+router.put('/:id/cancel', adminRouteLimiter, authMiddleware, requireAdminFlag, cancelBooking);
+router.put('/:id/pending', adminRouteLimiter, authMiddleware, requireAdminFlag, pendBookingById);
+router.put('/:id/request-change', adminRouteLimiter, authMiddleware, requireAdminFlag, submitNewDateRequest);
+router.put('/:id/update', adminRouteLimiter, authMiddleware, requireAdminFlag, updateBooking);
 
 
 // Reminder Scheduler

--- a/server/routes/api/bookingRoutes.js
+++ b/server/routes/api/bookingRoutes.js
@@ -3,6 +3,8 @@ const isDev = process.env.NODE_ENV !== "production";
 const cron = require('node-cron');
 const Booking = require('../../models/Booking');
 const NotificationService = require('../../services/NotificationService');
+const { authMiddleware } = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
 const { createBooking, getBookings, deleteBooking, completeBooking, hideBooking, sendScheduledReminder, sendScheduledConfirmationEmail, confirmBooking, cancelBooking, pendBookingById,
   updateBookingDate,
   submitNewDateRequest,
@@ -13,16 +15,16 @@ const { createBooking, getBookings, deleteBooking, completeBooking, hideBooking,
 
 router.post('/', createBooking);
 router.post('/request', submitNewBookingRequest);
-router.get('/', getBookings);
-router.delete('/:id', deleteBooking);
-router.put('/:id/update-date', updateBookingDate);
-router.put('/:id/complete', completeBooking);
-router.put('/:id/hide', hideBooking);
-router.put('/:id/confirm', confirmBooking);
-router.put('/:id/cancel', cancelBooking);
-router.put('/:id/pending', pendBookingById);
-router.put('/:id/request-change', submitNewDateRequest);
-router.put('/:id/update', updateBooking);
+router.get('/', authMiddleware, requireAdminFlag, getBookings);
+router.delete('/:id', authMiddleware, requireAdminFlag, deleteBooking);
+router.put('/:id/update-date', authMiddleware, requireAdminFlag, updateBookingDate);
+router.put('/:id/complete', authMiddleware, requireAdminFlag, completeBooking);
+router.put('/:id/hide', authMiddleware, requireAdminFlag, hideBooking);
+router.put('/:id/confirm', authMiddleware, requireAdminFlag, confirmBooking);
+router.put('/:id/cancel', authMiddleware, requireAdminFlag, cancelBooking);
+router.put('/:id/pending', authMiddleware, requireAdminFlag, pendBookingById);
+router.put('/:id/request-change', authMiddleware, requireAdminFlag, submitNewDateRequest);
+router.put('/:id/update', authMiddleware, requireAdminFlag, updateBooking);
 
 
 // Reminder Scheduler

--- a/server/routes/api/customerRoutes.js
+++ b/server/routes/api/customerRoutes.js
@@ -2,7 +2,9 @@ const router = require('express').Router();
 const { getAllCustomers, getCustomerById, createCustomer, deleteCustomer, updateCustomer, getCustomerStats, saveCustomerNotes, getCustomerNotes, assignUserToCustomer, getCustomerBookings, removeCustomerBooking   } = require('../../controllers/customerController');
 const { authMiddleware } = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { adminRouteLimiter } = require('../../middleware/rateLimiters');
 
+router.use(adminRouteLimiter);
 router.use(authMiddleware);
 router.use(requireAdminFlag);
 

--- a/server/routes/api/customerRoutes.js
+++ b/server/routes/api/customerRoutes.js
@@ -1,5 +1,10 @@
 const router = require('express').Router();
 const { getAllCustomers, getCustomerById, createCustomer, deleteCustomer, updateCustomer, getCustomerStats, saveCustomerNotes, getCustomerNotes, assignUserToCustomer, getCustomerBookings, removeCustomerBooking   } = require('../../controllers/customerController');
+const { authMiddleware } = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
+
+router.use(authMiddleware);
+router.use(requireAdminFlag);
 
 // POST /customers
 router.post('/', createCustomer); // Add a new customer

--- a/server/routes/api/emailRoutes.js
+++ b/server/routes/api/emailRoutes.js
@@ -9,6 +9,7 @@ const router = require('express').Router();
 const isDev = process.env.NODE_ENV !== "production";
 const { authMiddleware } = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { adminRouteLimiter } = require('../../middleware/rateLimiters');
 
 // Route for sending an email
 router.post('/quote', emailQuote);
@@ -23,11 +24,11 @@ router.post('/new-user-notification', emailNewUserNotification);
 
 router.post('/request-password-reset', emailPasswordResetRequest);
 
-router.get('/weekly-report', authMiddleware, requireAdminFlag, generateManualReport);
-router.post('/upcoming-bookings', authMiddleware, requireAdminFlag, sendUpcomingBookingsEmail);
+router.get('/weekly-report', adminRouteLimiter, authMiddleware, requireAdminFlag, generateManualReport);
+router.post('/upcoming-bookings', adminRouteLimiter, authMiddleware, requireAdminFlag, sendUpcomingBookingsEmail);
 
 // ✅ Manually trigger Admin Upcoming Bookings Digest
-router.post("/admin-upcoming-bookings-digest", authMiddleware, requireAdminFlag, async (req, res) => {
+router.post("/admin-upcoming-bookings-digest", adminRouteLimiter, authMiddleware, requireAdminFlag, async (req, res) => {
     try {
         const days = Number(req.body?.days || 7);
 

--- a/server/routes/api/emailRoutes.js
+++ b/server/routes/api/emailRoutes.js
@@ -7,6 +7,8 @@ const NotificationService = require('../../services/NotificationService');
 
 const router = require('express').Router();
 const isDev = process.env.NODE_ENV !== "production";
+const { authMiddleware } = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
 
 // Route for sending an email
 router.post('/quote', emailQuote);
@@ -21,11 +23,11 @@ router.post('/new-user-notification', emailNewUserNotification);
 
 router.post('/request-password-reset', emailPasswordResetRequest);
 
-router.get('/weekly-report', generateManualReport);
-router.post('/upcoming-bookings', sendUpcomingBookingsEmail);
+router.get('/weekly-report', authMiddleware, requireAdminFlag, generateManualReport);
+router.post('/upcoming-bookings', authMiddleware, requireAdminFlag, sendUpcomingBookingsEmail);
 
 // ✅ Manually trigger Admin Upcoming Bookings Digest
-router.post("/admin-upcoming-bookings-digest", async (req, res) => {
+router.post("/admin-upcoming-bookings-digest", authMiddleware, requireAdminFlag, async (req, res) => {
     try {
         const days = Number(req.body?.days || 7);
 

--- a/server/routes/api/userRoutes.js
+++ b/server/routes/api/userRoutes.js
@@ -5,11 +5,12 @@ const { getUsers, createUser, getUserById, deleteUser, updateUser, login, migrat
  } = require('../../controllers/userControllers');
 const {authMiddleware} = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { authRouteLimiter, adminRouteLimiter } = require('../../middleware/rateLimiters');
 
 router.route('/')
-    .get(authMiddleware, requireAdminFlag, getUsers)
+    .get(adminRouteLimiter, authMiddleware, requireAdminFlag, getUsers)
     .post(createUser)
-    .put(authMiddleware, updateUser);
+    .put(authRouteLimiter, authMiddleware, updateUser);
     
 router.route('/migrate-user').put(migrateUsernamesToLowercase);
 
@@ -22,7 +23,7 @@ router.route('/:userId')
 
 router.route('/reset-password').post(resetPassword);
 
-router.route('/me').get(authMiddleware, getUserById);
+router.route('/me').get(authRouteLimiter, authMiddleware, getUserById);
 
 router.route('/:userId/bookings').get(getUserBookings);
 

--- a/server/routes/api/userRoutes.js
+++ b/server/routes/api/userRoutes.js
@@ -6,6 +6,7 @@ const { getUsers, createUser, getUserById, deleteUser, updateUser, login, migrat
 const {authMiddleware} = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
 const { authRouteLimiter, adminRouteLimiter } = require('../../middleware/rateLimiters');
+const validateCsrfToken = require('../../middleware/validateCsrfToken');
 
 router.route('/')
     .get(adminRouteLimiter, authMiddleware, requireAdminFlag, getUsers)
@@ -28,8 +29,8 @@ router.route('/me').get(authRouteLimiter, authMiddleware, getUserById);
 router.route('/:userId/bookings').get(getUserBookings);
 
 router.route('/login').post(login);
-router.route('/logout').post(logout);
-router.route('/refresh').post(refreshToken);
+router.route('/logout').post(authRouteLimiter, validateCsrfToken, logout);
+router.route('/refresh').post(authRouteLimiter, validateCsrfToken, refreshToken);
 
 
 // router.route('/:userId/friends/:friendId')

--- a/server/routes/api/userRoutes.js
+++ b/server/routes/api/userRoutes.js
@@ -4,9 +4,10 @@ const { getUsers, createUser, getUserById, deleteUser, updateUser, login, migrat
     refreshToken
  } = require('../../controllers/userControllers');
 const {authMiddleware} = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
 
 router.route('/')
-    .get(getUsers)
+    .get(authMiddleware, requireAdminFlag, getUsers)
     .post(createUser)
     .put(authMiddleware, updateUser);
     

--- a/server/routes/api/visitorRoutes.js
+++ b/server/routes/api/visitorRoutes.js
@@ -1,4 +1,6 @@
 const router = require("express").Router();
+const { authMiddleware } = require('../../utils/auth');
+const requireAdminFlag = require('../../middleware/requireAdminFlag');
 
 const {
   logVisit,
@@ -23,26 +25,26 @@ const {
 // GET /api/visitors/logs  (recent logs)
 // POST /api/visitors/logs (create/update session log)
 router.route("/logs")
-  .get(getVisits)
+  .get(authMiddleware, requireAdminFlag, getVisits)
   .post(logVisit);
 
 // ---- Basic daily counts (legacy/simple) ----
 // GET /api/visitors/daily
-router.get("/daily", getDailyVisitors);
+router.get("/daily", authMiddleware, requireAdminFlag, getDailyVisitors);
 
 // ---- Migration ----
 // POST /api/visitors/migrate
-router.post("/migrate", migrateData);
+router.post("/migrate", authMiddleware, requireAdminFlag, migrateData);
 
 // ---- Reports (recommended) ----
 // GET /api/visitors/daily-report?date=YYYY-MM-DD&excludeBots=true
-router.get("/daily-report", getDailyReport);
+router.get("/daily-report", authMiddleware, requireAdminFlag, getDailyReport);
 
 // GET /api/visitors/weekly-report?end=YYYY-MM-DD&days=7&excludeBots=true
-router.get("/weekly-report", getWeeklyReport);
+router.get("/weekly-report", authMiddleware, requireAdminFlag, getWeeklyReport);
 
 // Keep your old path alive if your frontend already uses it:
-router.get("/weekly-reporting", getWeeklyReport);
+router.get("/weekly-reporting", authMiddleware, requireAdminFlag, getWeeklyReport);
 
 // ---- Legacy endpoints (still supported) ----
 router.post("/session-duration", updateSessionDuration);

--- a/server/routes/api/visitorRoutes.js
+++ b/server/routes/api/visitorRoutes.js
@@ -1,6 +1,7 @@
 const router = require("express").Router();
 const { authMiddleware } = require('../../utils/auth');
 const requireAdminFlag = require('../../middleware/requireAdminFlag');
+const { adminRouteLimiter } = require('../../middleware/rateLimiters');
 
 const {
   logVisit,
@@ -25,26 +26,26 @@ const {
 // GET /api/visitors/logs  (recent logs)
 // POST /api/visitors/logs (create/update session log)
 router.route("/logs")
-  .get(authMiddleware, requireAdminFlag, getVisits)
+  .get(adminRouteLimiter, authMiddleware, requireAdminFlag, getVisits)
   .post(logVisit);
 
 // ---- Basic daily counts (legacy/simple) ----
 // GET /api/visitors/daily
-router.get("/daily", authMiddleware, requireAdminFlag, getDailyVisitors);
+router.get("/daily", adminRouteLimiter, authMiddleware, requireAdminFlag, getDailyVisitors);
 
 // ---- Migration ----
 // POST /api/visitors/migrate
-router.post("/migrate", authMiddleware, requireAdminFlag, migrateData);
+router.post("/migrate", adminRouteLimiter, authMiddleware, requireAdminFlag, migrateData);
 
 // ---- Reports (recommended) ----
 // GET /api/visitors/daily-report?date=YYYY-MM-DD&excludeBots=true
-router.get("/daily-report", authMiddleware, requireAdminFlag, getDailyReport);
+router.get("/daily-report", adminRouteLimiter, authMiddleware, requireAdminFlag, getDailyReport);
 
 // GET /api/visitors/weekly-report?end=YYYY-MM-DD&days=7&excludeBots=true
-router.get("/weekly-report", authMiddleware, requireAdminFlag, getWeeklyReport);
+router.get("/weekly-report", adminRouteLimiter, authMiddleware, requireAdminFlag, getWeeklyReport);
 
 // Keep your old path alive if your frontend already uses it:
-router.get("/weekly-reporting", authMiddleware, requireAdminFlag, getWeeklyReport);
+router.get("/weekly-reporting", adminRouteLimiter, authMiddleware, requireAdminFlag, getWeeklyReport);
 
 // ---- Legacy endpoints (still supported) ----
 router.post("/session-duration", updateSessionDuration);

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -33,33 +33,37 @@ const buildUserPayload = (dbUserData) => {
 };
 
 module.exports = {
-  authMiddleware: function ({ req }) {
+  authMiddleware: function (reqOrContext, res, next) {
+    // Supports both Express middleware signature (req, res, next)
+    // and legacy resolver style ({ req }).
+    const req = reqOrContext?.req || reqOrContext;
+
+    if (!req) {
+      if (typeof next === 'function') return next();
+      return reqOrContext;
+    }
+
     // allows token to be sent via req.body, req.query, or headers
-    let token = req.body.token || req.query.token || req.headers.authorization;
+    let token = req.body?.token || req.query?.token || req.headers?.authorization;
 
     // ["Bearer", "<tokenvalue>"]
-    if (req.headers.authorization) {
+    if (req.headers?.authorization) {
       token = token
         .split(' ')
         .pop()
         .trim();
     }
 
-    console.log("token", token)
-
-
-    if (!token) {
-      return req;
+    if (token) {
+      try {
+        const { data } = jwt.verify(token, secret, { maxAge: expiration });
+        req.user = data;
+      } catch {
+        console.log('Invalid token');
+      }
     }
 
-    try {
-      const { data } = jwt.verify(token, secret, { maxAge: expiration });
-      req.user = data;
-    }
-    catch {
-      console.log('Invalid token');
-    }
-
+    if (typeof next === 'function') return next();
     return req;
   },
   signToken: function (dbUserData) {


### PR DESCRIPTION
### Motivation
- Ensure all client requests include an auth token and centralize header handling via a single helper.
- Restrict admin/management APIs and reporting endpoints to authenticated users with an admin flag.
- Provide a simple server-side middleware to gate admin-only routes and adapt the auth helper to work as Express middleware and resolver-style calls.

### Description
- Added a new client utility `authFetch` (`client/src/utils/authFetch.js`) that injects `Authorization: Bearer <token>` when available and replaced numerous `fetch` calls with `authFetch` across dashboard, booking, customer, events, logs, and reporting components.
- Updated routing and UI protection: `ProtectedRoute` now supports a `requireAdmin` prop and redirects unauthenticated users to `/login-signup` and non-admin users away from admin pages; updated route usages in `client/src/index.jsx` for admin areas.
- Introduced server middleware `requireAdminFlag` and applied `authMiddleware` + `requireAdminFlag` to admin-sensitive routes (bookings, visitors/reports, customers, email report endpoints, admin user routes, admin reports), and wired the admin reports route to require authentication.
- Adapted server auth utilities (`server/utils/auth.js`) to support both Express middleware signature and legacy resolver-style calls, safely extract tokens from headers/body/query, verify JWT and populate `req.user`.

### Testing
- Ran the frontend build (`npm run build`) to validate client-side compile after replacing `fetch` calls and it completed successfully.
- Ran the linter (`npm run lint`) to catch syntax/format issues and no lint errors remained.
- Executed the existing automated test suite (`npm test`) and the tests passed against the modified server and client code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e225280e648329b0bbb87875df20c7)