### PR TITLE
Potential fix for code scanning alert no. 71: Missing rate limiting

### DIFF
--- a/server/routes/api/serviceRoutes.js
+++ b/server/routes/api/serviceRoutes.js
@@ -1,12 +1,20 @@
 const router = require('express').Router();
+const rateLimit = require('express-rate-limit');
 const { getServices, createService, getServiceByName, getServiceById, updateService, deleteService, duplicateService } = require('../../controllers/serviceControllers');
+
+const duplicateServiceLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 duplicate requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+});
 
 router.route('/')
     .get(getServices)
     .post(createService);
 
 router.route('/duplicate/:serviceId')
-    .post(duplicateService)
+    .post(duplicateServiceLimiter, duplicateService)
 
 
 router.route('/:serviceId')


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/71](https://github.com/nickless192/ar-cleaning/security/code-scanning/71)

Add a rate-limiting middleware to `server/routes/api/serviceRoutes.js` and apply it to the `POST /duplicate/:serviceId` route before `duplicateService`.

Best implementation with minimal functional change:
- Import `express-rate-limit`.
- Define a limiter instance near the top of this routes file (for example: 100 requests per 15 minutes per IP).
- Attach that limiter to the duplicate route as middleware: `.post(duplicateServiceLimiter, duplicateService)`.
- Keep all existing controller behavior unchanged; only gate request frequency.

This keeps current routing and controllers intact while mitigating abusive request bursts against a DB-backed operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
