### PR TITLE
Potential fix for code scanning alert no. 211: Missing rate limiting

### DIFF
--- a/server/routes/api/userRoutes.js
+++ b/server/routes/api/userRoutes.js
@@ -20,7 +20,7 @@ router.route('/:userId')
     .put(updateUser)
     .delete(deleteUser);
 
-    router.route('/:userId/consent').patch(setUserConsent);
+    router.route('/:userId/consent').patch(authRouteLimiter, setUserConsent);
 
 router.route('/reset-password').post(authRouteLimiter, resetPassword);
 


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/211](https://github.com/nickless192/ar-cleaning/security/code-scanning/211)

Add a rate-limiting middleware to the consent PATCH route, matching existing conventions in this file.

Best fix (without changing behavior beyond protection): update `server/routes/api/userRoutes.js` line 23 route chain to include `authRouteLimiter` before `setUserConsent` (optionally before auth middleware if added later; currently this route has neither auth nor limiter in the shown code). Since `authRouteLimiter` is already imported at line 8, no new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
