### PR TITLE
Potential fix for code scanning alert no. 215: Missing rate limiting

### DIFF
--- a/server/routes/api/invoiceRoutes.js
+++ b/server/routes/api/invoiceRoutes.js
@@ -24,5 +24,5 @@ module.exports = router;
 
 ///by-booking/:bookingId
 router.get('/by-booking/:bookingId', getInvoiceByBooking);
-router.get("/:id/pdf", getInvoicePdf);
+router.get("/:id/pdf", authRouteLimiter, getInvoicePdf);
 router.post("/:id/send", authRouteLimiter,sendInvoice);


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/215](https://github.com/nickless192/ar-cleaning/security/code-scanning/215)

Add an existing rate-limiting middleware to the unprotected `GET /:id/pdf` route, matching current project patterns and avoiding functional changes to controller behavior.

Best fix in this file:
- In `server/routes/api/invoiceRoutes.js`, update line with `router.get("/:id/pdf", getInvoicePdf);`
- Apply `authRouteLimiter` (already imported and used in this file) before `getInvoicePdf`.

This preserves endpoint behavior while adding request throttling. No new methods or imports are needed because `authRouteLimiter` is already in scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
