### PR TITLE
Potential fix for code scanning alert no. 145: Database query built from user-controlled sources

### DIFF
--- a/server/controllers/visitorController.js
+++ b/server/controllers/visitorController.js
@@ -1281,10 +1281,12 @@ getVisits: async (req, res) => {
  sessionExit: async (req, res) => {
   try {
     const { sessionId, page, lastSeenAt } = req.body;
-    if (!sessionId) return res.status(400).json({ error: "Missing sessionId" });
+    if (typeof sessionId !== "string" || !sessionId.trim()) {
+      return res.status(400).json({ error: "Missing or invalid sessionId" });
+    }
 
     // Read current doc (needed because you compute derived fields)
-    const doc = await VisitorLog.findOne({ sessionId }).lean();
+    const doc = await VisitorLog.findOne({ sessionId: { $eq: sessionId } }).lean();
     if (!doc) return res.status(404).json({ error: "Session not found" });
 
     const computedLastSeenAt = lastSeenAt ? new Date(lastSeenAt) : new Date();
@@ -1317,7 +1319,7 @@ getVisits: async (req, res) => {
 
     // ✅ Atomic write (no doc.save → no VersionError)
     const updated = await VisitorLog.findOneAndUpdate(
-      { sessionId },
+      { sessionId: { $eq: sessionId } },
       {
         $set: {
           lastSeenAt: computedLastSeenAt,


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/145](https://github.com/nickless192/ar-cleaning/security/code-scanning/145)

The safest fix is to ensure `sessionId` is treated as a literal value, not a query object, before using it in Mongo filters. In this controller, do two things:

1. Validate `sessionId` is a non-empty string (reject objects/arrays/numbers).
2. Use Mongo `$eq` in query predicates to force literal comparison.

Apply this within `sessionExit` in `server/controllers/visitorController.js`:
- Right after extracting `sessionId` from `req.body`, add strict type/empty checks.
- Replace both query filters:
  - `VisitorLog.findOne({ sessionId })` → `VisitorLog.findOne({ sessionId: { $eq: sessionId } })`
  - `findOneAndUpdate({ sessionId }, ...)` → `findOneAndUpdate({ sessionId: { $eq: sessionId } }, ...)`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
