### PR TITLE
Harden CodeQL sinks: validate DB inputs, add home route rate limiting, fix i18n prototype pollution

### DIFF
--- a/server/controllers/bookingController.js
+++ b/server/controllers/bookingController.js
@@ -509,22 +509,23 @@ const bookingControllers = {
       // res.json(updatedBooking);
 
       const safeBookingFilter = { _id: bookingId };
+      const safeUpdatedBy = isValidObjectId(req.body.updatedBy) ? req.body.updatedBy : null;
+      const safeBookingUpdate = {
+        status,
+        scheduleConfirmation: scheduleConfirmation || false,
+        scheduledConfirmationDate: confirmationDate
+          ? parseTorontoWallTimeToUTCDate(confirmationDate)
+          : new Date(),
+        reminderScheduled: reminderScheduled || false,
+        disableConfirmation: disableConfirmation || false,
+        updatedAt: new Date()
+      };
+      if (safeUpdatedBy) {
+        safeBookingUpdate.updatedBy = safeUpdatedBy;
+      }
       const updatedBooking = await Booking.findOneAndUpdate(
         safeBookingFilter,
-        {
-          status,
-          scheduleConfirmation: scheduleConfirmation || false,
-          // scheduledConfirmationDate: confirmationDate
-          //   ? DateTime.fromISO(confirmationDate, { zone: 'America/Toronto' }).toJSDate()
-          //   : new Date(),
-          scheduledConfirmationDate: confirmationDate
-            ? parseTorontoWallTimeToUTCDate(confirmationDate)
-            : new Date(),
-          reminderScheduled: reminderScheduled || false,
-          disableConfirmation: disableConfirmation || false,
-          updatedAt: new Date(),
-          updatedBy: req.body.updatedBy
-        },
+        { $set: safeBookingUpdate },
         { new: true }
       );
       // if (customerSuggestedBookingAcknowledged) {
@@ -692,8 +693,15 @@ const bookingControllers = {
         return res.status(400).json({ error: 'Invalid booking id' });
       }
       const safeBookingFilter = { _id: bookingId };
+      const safeBookingUpdate = {
+        notes,
+        updatedAt: new Date()
+      };
+      if (isValidObjectId(updatedBy)) {
+        safeBookingUpdate.updatedBy = updatedBy;
+      }
       const updatedBooking = await Booking.findOneAndUpdate(safeBookingFilter,
-        { notes, updatedBy, updatedAt: new Date() },
+        { $set: safeBookingUpdate },
         { new: true }
       );
       if (!updatedBooking) {
@@ -714,20 +722,21 @@ const bookingControllers = {
         return res.status(400).json({ error: 'Invalid booking id' });
       }
       const safeBookingFilter = { _id: bookingId };
+      const safeBookingUpdate = {
+        date: parseTorontoWallTimeToUTCDate(date),
+        updatedAt: new Date(),
+        status: 'pending',
+        scheduledConfirmationDate: null,
+        reminderScheduled: false,
+        confirmationSent: false,
+        reminderSent: false,
+        disableConfirmation: false
+      };
+      if (isValidObjectId(updatedBy)) {
+        safeBookingUpdate.updatedBy = updatedBy;
+      }
       const updatedBooking = await Booking.findOneAndUpdate(safeBookingFilter,
-        // { date: new Date(date), updatedBy, updatedAt: new Date() },
-        {
-          // date: new Date(date),
-          date: parseTorontoWallTimeToUTCDate(date),
-          updatedBy,
-          updatedAt: new Date(),
-          status: 'pending',
-          scheduledConfirmationDate: null,
-          reminderScheduled: false,
-          confirmationSent: false,
-          reminderSent: false,
-          disableConfirmation: false
-        },
+        { $set: safeBookingUpdate },
         { new: true }
       );
       if (!updatedBooking) {

--- a/server/controllers/emailController.js
+++ b/server/controllers/emailController.js
@@ -1568,7 +1568,12 @@ CleanAR Solutions`;
   },
   emailPasswordResetRequest: async (req, res) => {
     const { email } = req.body;
-    const user = await User.findOne({ email });
+    const safeEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
+    if (!safeEmail) {
+      return res.status(400).send('Valid email is required');
+    }
+    const safeUserFilter = { email: safeEmail };
+    const user = await User.findOne(safeUserFilter);
 
     if (!user) {
       return res.status(404).send('User not found');

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -133,11 +133,67 @@ const getMyNotificationSettings = async (req, res) => {
 const updateMyNotificationSettings = async (req, res) => {
     try {
         const userId = req.user._id;
-        const preferences = req.body.preferences || {};
+        if (!isValidObjectId(String(userId))) {
+            return res.status(400).json({ message: 'Invalid user id.' });
+        }
+        const rawPreferences =
+            req.body && typeof req.body.preferences === 'object' && req.body.preferences !== null
+                ? req.body.preferences
+                : {};
+        const safePreferences = {};
+        if (
+            rawPreferences.bookingConfirmation &&
+            typeof rawPreferences.bookingConfirmation === 'object'
+        ) {
+            safePreferences.bookingConfirmation = {};
+            if (typeof rawPreferences.bookingConfirmation.email === 'boolean') {
+                safePreferences.bookingConfirmation.email =
+                    rawPreferences.bookingConfirmation.email;
+            }
+        }
+        if (rawPreferences.bookingReminder && typeof rawPreferences.bookingReminder === 'object') {
+            safePreferences.bookingReminder = {};
+            if (typeof rawPreferences.bookingReminder.email === 'boolean') {
+                safePreferences.bookingReminder.email = rawPreferences.bookingReminder.email;
+            }
+            if (
+                rawPreferences.bookingReminder.frequency === 'immediate' ||
+                rawPreferences.bookingReminder.frequency === 'daily' ||
+                rawPreferences.bookingReminder.frequency === 'weekly'
+            ) {
+                safePreferences.bookingReminder.frequency =
+                    rawPreferences.bookingReminder.frequency;
+            }
+        }
+        if (
+            rawPreferences.adminUpcomingBookings &&
+            typeof rawPreferences.adminUpcomingBookings === 'object'
+        ) {
+            safePreferences.adminUpcomingBookings = {};
+            if (typeof rawPreferences.adminUpcomingBookings.email === 'boolean') {
+                safePreferences.adminUpcomingBookings.email =
+                    rawPreferences.adminUpcomingBookings.email;
+            }
+            if (
+                rawPreferences.adminUpcomingBookings.frequency === 'daily' ||
+                rawPreferences.adminUpcomingBookings.frequency === 'weekly'
+            ) {
+                safePreferences.adminUpcomingBookings.frequency =
+                    rawPreferences.adminUpcomingBookings.frequency;
+            }
+        }
+        if (rawPreferences.marketing && typeof rawPreferences.marketing === 'object') {
+            safePreferences.marketing = {};
+            if (typeof rawPreferences.marketing.email === 'boolean') {
+                safePreferences.marketing.email = rawPreferences.marketing.email;
+            }
+        }
 
+        const safeSettingsFilter = { user: userId };
+        const safeSettingsUpdate = { $set: { preferences: safePreferences } };
         const settings = await UserNotificationSettings.findOneAndUpdate(
-            { user: userId },
-            { preferences },
+            safeSettingsFilter,
+            safeSettingsUpdate,
             { upsert: true, new: true }
         );
 

--- a/server/controllers/userControllers.js
+++ b/server/controllers/userControllers.js
@@ -114,7 +114,12 @@ const userControllers = {
     },
     async login({ body }, res) {
         // const dbUserData = await User.findOne({ email: body.email });
-        const dbUserData = await User.findOne({ email: body.email })
+        const safeEmail = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : '';
+        if (!safeEmail) {
+            return res.status(400).json({ message: 'Email is required.' });
+        }
+        const safeUserFilter = { email: safeEmail };
+        const dbUserData = await User.findOne(safeUserFilter)
             .select('-resetToken -resetTokenExpires') // keep sensitive tokens out
             .populate({
                 path: 'roles',

--- a/server/controllers/visitorController.js
+++ b/server/controllers/visitorController.js
@@ -115,6 +115,14 @@ function coerceSafeSessionId(sessionId) {
   return trimmed;
 }
 
+function coerceSafeVisitorId(visitorId) {
+  if (typeof visitorId !== "string") return null;
+  const trimmed = visitorId.trim();
+  if (!trimmed) return null;
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(trimmed)) return null;
+  return trimmed;
+}
+
 function getValidatedSessionId(sessionId) {
   if (typeof sessionId !== "string") return null;
   const trimmed = sessionId.trim();
@@ -458,6 +466,9 @@ const visitorController = {
       const validatedSessionId = coerceSafeSessionId(getValidatedSessionId(sessionId));
       const effectiveSessionId = validatedSessionId || crypto.randomUUID();
       const visitorId = clientVisitorId || generateFallbackVisitorId(req);
+      const safeSessionId = coerceSafeSessionId(effectiveSessionId);
+      const safeVisitorId = coerceSafeVisitorId(visitorId) || generateFallbackVisitorId(req);
+      if (!safeSessionId) return res.status(400).json({ error: "Missing sessionId" });
 
       const ip = getClientIp(req);
       const hashedIp = hashIp(ip);
@@ -490,26 +501,28 @@ const visitorController = {
       }
 
       // Returning visitor (fast + correct): VisitorIdentity
+      const safeVisitorFilter = { visitorId: safeVisitorId };
+      const safeReturningVisitorFilter = { visitorId: safeVisitorId, sessionId: { $ne: safeSessionId } };
       let isReturningVisitor = false;
       try {
         if (VisitorIdentity) {
           const prev = await VisitorIdentity.findOneAndUpdate(
-            { visitorId },
+            safeVisitorFilter,
             {
-              $set: { lastSeenAt: now, lastSessionId: effectiveSessionId },
-              $setOnInsert: { firstSeenAt: now, firstSessionId: effectiveSessionId },
+              $set: { lastSeenAt: now, lastSessionId: safeSessionId },
+              $setOnInsert: { firstSeenAt: now, firstSessionId: safeSessionId },
             },
             { new: false, upsert: true }
           );
           isReturningVisitor = !!prev;
         } else {
           // fallback (less ideal): check visitorId exists with different sessionId
-          const prev = await VisitorLog.exists({ visitorId, sessionId: { $ne: effectiveSessionId } });
+          const prev = await VisitorLog.exists(safeReturningVisitorFilter);
           isReturningVisitor = !!prev;
         }
       } catch (e) {
         console.error("[VisitorIdentity] failed:", e.message);
-        const prev = await VisitorLog.exists({ visitorId, sessionId: { $ne: effectiveSessionId } });
+        const prev = await VisitorLog.exists(safeReturningVisitorFilter);
         isReturningVisitor = !!prev;
       }
 
@@ -520,8 +533,8 @@ const visitorController = {
 
       const update = {
         $setOnInsert: {
-          visitorId,
-          sessionId: effectiveSessionId,
+          visitorId: safeVisitorId,
+          sessionId: safeSessionId,
           visitDate: now,
           firstSeenAt: now,
           page: pageNorm, // landing page
@@ -552,15 +565,13 @@ const visitorController = {
         update.$push = { pathsVisited: { $each: safePaths, $slice: -50 } };
       }
 
-      const safeSessionId = coerceSafeSessionId(effectiveSessionId);
-      if (!safeSessionId) return res.status(400).json({ error: "Missing sessionId" });
       const safeSessionFilter = { sessionId: safeSessionId };
       await VisitorLog.findOneAndUpdate(safeSessionFilter, update, {
         new: true,
         upsert: true,
       });
 
-      res.status(200).json({ message: "Visit logged/updated", sessionId: effectiveSessionId, visitorId });
+      res.status(200).json({ message: "Visit logged/updated", sessionId: safeSessionId, visitorId: safeVisitorId });
     } catch (err) {
       console.error("logVisit error:", err);
       res.status(500).send({ error: "Failed to log visit" });

--- a/server/routes/homeRoutes.js
+++ b/server/routes/homeRoutes.js
@@ -1,7 +1,8 @@
 const router = require('express').Router();
 const path = require('path');
+const { authRouteLimiter } = require('../middleware/rateLimiters');
 
-router.get('*', (req, res) => {
+router.get('*', authRouteLimiter, (req, res) => {
     res.sendFile(path.join(__dirname, '../client/dist', 'index.html'));
   });
 

--- a/server/utils/i18nStore.js
+++ b/server/utils/i18nStore.js
@@ -46,7 +46,10 @@ function setByDotPath(obj, dotPath, value) {
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
     assertSafePathKey(k);
-    if (cur[k] == null || typeof cur[k] !== "object") cur[k] = Object.create(null);
+    const hasOwn = Object.prototype.hasOwnProperty.call(cur, k);
+    if (!hasOwn || cur[k] == null || typeof cur[k] !== "object") {
+      cur[k] = Object.create(null);
+    }
     cur = cur[k];
   }
   const finalKey = parts[parts.length - 1];

--- a/server/utils/i18nStore.js
+++ b/server/utils/i18nStore.js
@@ -45,10 +45,13 @@ function setByDotPath(obj, dotPath, value) {
 
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
-    if (cur[k] == null || typeof cur[k] !== "object") cur[k] = {};
+    assertSafePathKey(k);
+    if (cur[k] == null || typeof cur[k] !== "object") cur[k] = Object.create(null);
     cur = cur[k];
   }
-  cur[parts[parts.length - 1]] = value;
+  const finalKey = parts[parts.length - 1];
+  assertSafePathKey(finalKey);
+  cur[finalKey] = value;
 }
 
 function removeByDotPath(obj, dotPath) {


### PR DESCRIPTION
### Motivation
- Close remaining CodeQL findings for "Database query built from user-controlled sources" by preventing raw request values from reaching Mongoose sinks. 
- Add missing rate limiting on the SPA wildcard route using the project's existing limiter. 
- Eliminate prototype-pollution risk in dynamic i18n path writes while keeping behavior unchanged.

### Description
- Validate and coerce visitor/session identifiers in `server/controllers/visitorController.js` by adding `coerceSafeVisitorId`, creating `safeVisitorFilter`/`safeReturningVisitorFilter`, and using `safeSessionId`/`safeVisitorId` in `findOneAndUpdate`/`exists` calls. 
- Normalize and require emails in `server/controllers/userControllers.js` and `server/controllers/emailController.js` by creating `safeEmail` and `safeUserFilter` before `User.findOne`. 
- Replace direct `req.body.preferences` and other object pass-throughs in `server/controllers/notificationController.js` with an allowlisted `safePreferences` and explicit `safeSettingsFilter`/`safeSettingsUpdate` used at the `findOneAndUpdate` sink. 
- Replace inline request-derived update objects in `server/controllers/bookingController.js` with explicit `safeBookingUpdate` locals and validate `updatedBy` with `isValidObjectId` before including it. 
- Reuse existing rate limiter by applying `authRouteLimiter` from `server/middleware/rateLimiters.js` to the wildcard route in `server/routes/homeRoutes.js`. 
- Harden `server/utils/i18nStore.js` by enforcing key checks per segment and creating intermediate objects with `Object.create(null)` and validating the final key to prevent prototype pollution. 
- Modified files: `server/controllers/visitorController.js`, `server/controllers/userControllers.js`, `server/controllers/emailController.js`, `server/controllers/notificationController.js`, `server/controllers/bookingController.js`, `server/routes/homeRoutes.js`, `server/utils/i18nStore.js`.

### Testing
- Ran syntax checks with `node --check` against all modified files and they passed successfully. 
- No new dependencies were added and the changes are limited to the flagged sinks and closely related code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e9a5c9f08329a2df8602db20822c)