### PR TITLE
Potential fix for code scanning alert no. 232: Prototype-polluting function

### DIFF
--- a/server/utils/i18nStore.js
+++ b/server/utils/i18nStore.js
@@ -47,13 +47,17 @@ function setByDotPath(obj, dotPath, value) {
     const k = parts[i];
     assertSafePathKey(k);
     const hasOwn = Object.prototype.hasOwnProperty.call(cur, k);
-    if (!hasOwn || cur[k] == null || typeof cur[k] !== "object") {
+    const next = hasOwn ? cur[k] : undefined;
+    if (!hasOwn || next == null || typeof next !== "object") {
       cur[k] = Object.create(null);
     }
     cur = cur[k];
   }
   const finalKey = parts[parts.length - 1];
   assertSafePathKey(finalKey);
+  if (cur == null || typeof cur !== "object") {
+    throw new Error("Invalid destination object");
+  }
   cur[finalKey] = value;
 }
 
@@ -63,10 +67,14 @@ function removeByDotPath(obj, dotPath) {
 
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
-    if (cur[k] == null || typeof cur[k] !== "object") return; // nothing to remove
+    assertSafePathKey(k);
+    const hasOwn = Object.prototype.hasOwnProperty.call(cur, k);
+    if (!hasOwn || cur[k] == null || typeof cur[k] !== "object") return; // nothing to remove
     cur = cur[k];
   }
-  delete cur[parts[parts.length - 1]];
+  const finalKey = parts[parts.length - 1];
+  assertSafePathKey(finalKey);
+  delete cur[finalKey];
 }
 
 function flattenKeys(obj, prefix = "") {


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/232](https://github.com/nickless192/ar-cleaning/security/code-scanning/232)

General fix: in deep path traversal/assignment helpers, only recurse into own properties of the destination object; if missing/non-object, create a safe own container. Also apply the same own-property rule to deletion traversal.

Best concrete fix in `server/utils/i18nStore.js`:
- In `setByDotPath` loop (around lines 46–54), keep the existing safety checks but when advancing `cur`, do not directly use `cur[k]` without guaranteeing it is own/object. Normalize to an own `Object.create(null)` container when needed, then traverse.
- Before final assignment (line 57), re-assert destination is object-like (defensive).
- In `removeByDotPath` loop (lines 64–68), add `hasOwnProperty` checks before traversing to avoid inherited-chain traversal.
- Validate final key with `assertSafePathKey` in `removeByDotPath` too.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
