### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - staging  # Change this to the name of your staging branch
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/1](https://github.com/nickless192/ar-cleaning/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/deploy-staging.yml` so the workflow does not rely on repository/org defaults.  
Best single fix without changing functionality: define permissions at the workflow root (applies to all jobs) with the minimal baseline `contents: read`, which is sufficient for `actions/checkout` and typical build/deploy flows unless a step explicitly needs more. This addresses the CodeQL finding while preserving current behavior as much as possible.

**Where to change:**
- File: `.github/workflows/deploy-staging.yml`
- Region: near the top-level keys, directly after the `on:` trigger block and before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
