### PR TITLE
Potential fix for code scanning alert no. 232: Prototype-polluting function

### DIFF
--- a/server/utils/i18nStore.js
+++ b/server/utils/i18nStore.js
@@ -48,14 +48,20 @@ function setByDotPath(obj, dotPath, value) {
     assertSafePathKey(k);
     const hasOwn = Object.prototype.hasOwnProperty.call(cur, k);
     const next = hasOwn ? cur[k] : undefined;
-    if (!hasOwn || next == null || typeof next !== "object") {
+    const canDescend =
+      hasOwn &&
+      next != null &&
+      typeof next === "object" &&
+      !Array.isArray(next);
+
+    if (!canDescend) {
       cur[k] = Object.create(null);
     }
     cur = cur[k];
   }
   const finalKey = parts[parts.length - 1];
   assertSafePathKey(finalKey);
-  if (cur == null || typeof cur !== "object") {
+  if (cur == null || typeof cur !== "object" || Array.isArray(cur)) {
     throw new Error("Invalid destination object");
   }
   cur[finalKey] = value;


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/232](https://github.com/nickless192/ar-cleaning/security/code-scanning/232)

General fix: in deep assignment, only recurse into an existing nested object when it is an **own property** and a safe plain object; otherwise replace with a null-prototype object. Also ensure final write happens only on a valid own-object destination, not inherited structure.

Best concrete fix in `server/utils/i18nStore.js`:
- In `setByDotPath` loop (lines around 46–55), keep `hasOwn` check and strengthen recursive descent condition so we only reuse `next` when it is an own, non-null object and not an array; otherwise assign a fresh `Object.create(null)`.
- Before final assignment (line 61), keep current object check and add a defensive own-property gate for the destination traversal result (already effectively ensured by loop, but explicit check helps static analyzers).
- Keep existing `assertSafePathKey` logic unchanged.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
