### PR TITLE
Potential fix for code scanning alert no. 232: Prototype-polluting function

### DIFF
--- a/server/utils/i18nStore.js
+++ b/server/utils/i18nStore.js
@@ -64,6 +64,11 @@ function setByDotPath(obj, dotPath, value) {
   if (cur == null || typeof cur !== "object" || Array.isArray(cur)) {
     throw new Error("Invalid destination object");
   }
+  const finalHasOwn = Object.prototype.hasOwnProperty.call(cur, finalKey);
+  const finalExists = finalKey in cur;
+  if (!finalHasOwn && finalExists) {
+    throw new Error("Refusing to assign inherited property");
+  }
   cur[finalKey] = value;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/nickless192/ar-cleaning/security/code-scanning/232](https://github.com/nickless192/ar-cleaning/security/code-scanning/232)

General fix: in deep-assignment helpers, only recurse/write through safe keys and only descend into own object properties of the current destination object. This prevents writing through inherited prototype accessors and satisfies secure merge/assignment guidance.

Best concrete fix here (in `server/utils/i18nStore.js`, inside `setByDotPath`): strengthen the final write step to avoid assigning via inherited properties. Specifically, after validating `finalKey`, check whether `finalKey` is an own property of `cur` or not present on `cur` at all; if it exists only via prototype inheritance, throw an error. Then perform assignment. This preserves normal set behavior for valid locale keys while blocking ambiguous inherited targets.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
