### PR TITLE
Add CSRF header from cookie in authFetch for mutating requests

### DIFF
--- a/client/src/utils/authFetch.js
+++ b/client/src/utils/authFetch.js
@@ -1,16 +1,29 @@
 import Auth from "/src/utils/auth";
 
-export const withAuthHeaders = (headers = {}) => {
+const getCsrfToken = () => {
+  if (typeof document === "undefined") return "";
+  const cookiePrefix = "; csrfToken=";
+  const cookieValue = `; ${document.cookie}`;
+  const parts = cookieValue.split(cookiePrefix);
+  if (parts.length !== 2) return "";
+  return parts.pop()?.split(";").shift() || "";
+};
+
+export const withAuthHeaders = (headers = {}, method = "GET") => {
   const token = Auth.getToken();
+  const csrfToken = getCsrfToken();
+  const isStateChanging = !["GET", "HEAD", "OPTIONS"].includes(String(method).toUpperCase());
+
   return {
     ...headers,
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(isStateChanging && csrfToken ? { "x-csrf-token": csrfToken } : {}),
   };
 };
 
 export const authFetch = (url, options = {}) => {
   return fetch(url, {
     ...options,
-    headers: withAuthHeaders(options.headers),
+    headers: withAuthHeaders(options.headers, options.method),
   });
 };


### PR DESCRIPTION
### Motivation
- Fix 403 `Invalid CSRF token` failures on state-changing API calls (e.g. `PUT /api/bookings/:id/confirm`) by ensuring the frontend echoes the server-set `csrfToken` cookie as the expected `x-csrf-token` header used by server CSRF middleware.

### Description
- Modified `client/src/utils/authFetch.js` to read the `csrfToken` value from `document.cookie` and automatically include `x-csrf-token` for non-`GET/HEAD/OPTIONS` requests while preserving existing `Authorization` header behavior; no backend, route, or component changes were made and `BookingCalendar` requires no edits.

### Testing
- Ran `node --check client/src/utils/authFetch.js` which succeeded, and verified the change was committed as a single-file patch (`client/src/utils/authFetch.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e614a153e88329a8103997b851a697)