### PR TITLE
Add authFetch for authenticated API calls and CSRF handling; replace raw fetch usages; remove tab persistence

### DIFF
--- a/client/src/components/Pages/Dashboards/FinanceDashboard.jsx
+++ b/client/src/components/Pages/Dashboards/FinanceDashboard.jsx
@@ -5,6 +5,7 @@ import {
 } from 'reactstrap';
 import moment from 'moment';
 import RechartMonthly from './RechartMonthly';
+import { authFetch } from '/src/utils/authFetch';
 
 const FY_START_MONTH = 6; // June
 const currency = (n) => `$${Number(n || 0).toFixed(2)}`;
@@ -106,7 +107,7 @@ const FinanceDashboard = () => {
     setErrMsg('');
     try {
       const qs = buildQuery();
-      const res = await fetch(`/api/finance/summary?${qs}`);
+      const res = await authFetch(`/api/finance/summary?${qs}`);
       const json = await res.json();
       if (!res.ok) throw new Error(json?.error || 'Failed to fetch finance summary');
       setSummary(json);

--- a/client/src/components/Pages/Management/ManageProduct.jsx
+++ b/client/src/components/Pages/Management/ManageProduct.jsx
@@ -5,6 +5,7 @@
 //  * @returns {JSX.Element} ManageProduct component
 //  */
 import React, { useState, useEffect } from 'react';
+import { authFetch } from '/src/utils/authFetch';
 import {
     Button,
     Container,
@@ -48,7 +49,7 @@ const ManageProduct = () => {
             quantityAtHand
         });
 
-        fetch(`/api/products/${editingProductId}`, {
+        authFetch(`/api/products/${editingProductId}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json'
@@ -77,7 +78,7 @@ const ManageProduct = () => {
     };
 
     const handleDeleteClick = () => {
-        fetch(`/api/products/${editingProductId}`, {
+        authFetch(`/api/products/${editingProductId}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'
@@ -120,7 +121,7 @@ const ManageProduct = () => {
                 productCost: formData.productCost,
                 quantityAtHand: formData.quantityAtHand
             };
-            fetch('/api/products', {
+            authFetch('/api/products', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -149,7 +150,7 @@ const ManageProduct = () => {
     };
 
     useEffect(() => {
-        fetch('/api/products', {
+        authFetch('/api/products', {
             method: 'get',
             headers: {
                 'Content-Type': 'application/json',

--- a/client/src/components/Pages/Management/ManageService.jsx
+++ b/client/src/components/Pages/Management/ManageService.jsx
@@ -17,6 +17,7 @@ import { Button, Form, Row, Col, Card, Table, ButtonGroup } from 'react-bootstra
 import { FaEdit, FaTrash, FaCopy } from 'react-icons/fa';
 
 import { v4 as uuidv4 } from 'uuid';
+import { authFetch } from '/src/utils/authFetch';
 import { t } from 'i18next';
 
 const ManageService = () => {
@@ -78,7 +79,7 @@ const ManageService = () => {
         const confirmed = window.confirm(`Are you sure you want to duplicate "${service.name}"?`);
         if (!confirmed) return;
         try {
-            const response = await fetch(`/api/services/duplicate/${service._id}`, {
+            const response = await authFetch(`/api/services/duplicate/${service._id}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -125,7 +126,7 @@ const ManageService = () => {
         // api call to delete service
         const confirmed = window.confirm("Are you sure you want to delete this service?");
         if (!confirmed) return;
-        fetch(`/api/services/${serviceId}`, {
+        authFetch(`/api/services/${serviceId}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'
@@ -172,7 +173,7 @@ const ManageService = () => {
             const body = JSON.stringify(formData);
             const method = editingServiceId ? 'PUT' : 'POST';
             const url = editingServiceId ? `/api/services/${editingServiceId}` : '/api/services';
-            fetch(url, {
+            authFetch(url, {
                 method: method,
                 headers: {
                     'Content-Type': 'application/json'
@@ -308,7 +309,7 @@ const ManageService = () => {
     };
 
     const fetchServices = async () => {
-        fetch('/api/services', {
+        authFetch('/api/services', {
             method: 'get',
             headers: {
                 'Content-Type': 'application/json',
@@ -321,7 +322,7 @@ const ManageService = () => {
     };
 
     const fetchCategories = async () => {
-        fetch('/api/categories', {
+        authFetch('/api/categories', {
             method: 'get',
             headers: {
                 'Content-Type': 'application/json',

--- a/client/src/components/Pages/ManagementViews/AccountingTabbedView.jsx
+++ b/client/src/components/Pages/ManagementViews/AccountingTabbedView.jsx
@@ -8,8 +8,6 @@ import FinanceDashboard from "/src/components/Pages/Dashboards/FinanceDashboard"
 import InventoryManagementTabbedView from "/src/components/Pages/ManagementViews/InventoryManagementTabbedView"; // adjust path if needed
 import MonthlyProfitCompare from "/src/components/Pages/Dashboards/MonthlyProfitCompare";
 
-const LS_KEY = "accountingHubActiveTab";
-
 const AccountingTabbedView = () => {
   const { t } = useTranslation();
 
@@ -46,16 +44,6 @@ const AccountingTabbedView = () => {
 
   const [activeTab, setActiveTab] = useState("overview");
 
-  // restore last selected tab
-  useEffect(() => {
-    const saved = localStorage.getItem(LS_KEY);
-    if (saved && tabs.some((x) => x.key === saved)) setActiveTab(saved);
-  }, [tabs]);
-
-  // persist tab selection
-  useEffect(() => {
-    localStorage.setItem(LS_KEY, activeTab);
-  }, [activeTab]);
 
   const active = tabs.find((x) => x.key === activeTab) || tabs[0];
 

--- a/client/src/utils/authFetch.js
+++ b/client/src/utils/authFetch.js
@@ -21,9 +21,33 @@ export const withAuthHeaders = (headers = {}, method = "GET") => {
   };
 };
 
-export const authFetch = (url, options = {}) => {
-  return fetch(url, {
+const DEBUG_ENDPOINT_PATTERNS = [
+  '/api/bookings',
+  '/api/finance/',
+  '/api/invoices',
+  '/api/customers',
+];
+
+const shouldDebugAuthFetch = (url) =>
+  typeof url === 'string' && DEBUG_ENDPOINT_PATTERNS.some((pattern) => url.includes(pattern));
+
+export const authFetch = async (url, options = {}) => {
+  const headers = withAuthHeaders(options.headers, options.method);
+  const res = await fetch(url, {
     ...options,
-    headers: withAuthHeaders(options.headers, options.method),
+    headers,
   });
+
+  if (shouldDebugAuthFetch(url)) {
+    const hasAuthHeader = Boolean(headers.Authorization);
+    console.info('[authFetch]', {
+      url,
+      method: (options.method || 'GET').toUpperCase(),
+      hasAuthHeader,
+      status: res.status,
+      ok: res.ok,
+    });
+  }
+
+  return res;
 };


### PR DESCRIPTION
### Motivation
- Ensure frontend API calls include authentication and CSRF headers for state-changing requests. 
- Replace ad-hoc `fetch` calls with a single helper to centralize header logic and debugging. 
- Remove persisted UI state for the accounting tabs to simplify behavior and avoid stale localStorage state.

### Description
- Add `client/src/utils/authFetch.js` which exposes `withAuthHeaders` and `authFetch`, reads a CSRF token from cookies, attaches `Authorization` and `x-csrf-token` when appropriate, and logs debug info for selected API patterns. 
- Replace direct `fetch(...)` calls with `authFetch(...)` across multiple components including `FinanceDashboard.jsx`, `ManageProduct.jsx`, `ManageService.jsx`, and others to ensure consistent auth header usage. 
- Update imports to include `authFetch` where needed. 
- Remove localStorage-based tab restore/persist logic from `AccountingTabbedView.jsx`.

### Testing
- Ran the project test suite with `npm test` and all tests passed. 
- Ran linting with `npm run lint` and no new linting errors were introduced. 
- Performed a production build with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69ec034cc83299f44cace06ce71c9)