### PR TITLE
Remove temporary on-screen debug logging panels

### DIFF
--- a/client/src/components/Pages/Dashboards/AccountingOverview.jsx
+++ b/client/src/components/Pages/Dashboards/AccountingOverview.jsx
@@ -29,7 +29,6 @@ import {
   computeUnpaidInvoiceTotals,
   getCurrentMonthMetrics,
 } from './accountingOverviewAdapters';
-import Auth from "/src/utils/auth";
 import { authFetch } from "/src/utils/authFetch";
 
 const currency = (n) => `$${Number(n || 0).toFixed(2)}`;
@@ -69,37 +68,7 @@ export default function AccountingOverview() {
   const [trendItems, setTrendItems] = useState([]);
   const [invoices, setInvoices] = useState([]);
   const [bookings, setBookings] = useState([]);
-  const [debugState, setDebugState] = useState({
-    mounted: false,
-    isMobileViewport: false,
-    hasToken: false,
-    isAdmin: false,
-    loaderStarted: false,
-    failed: false,
-    statuses: {
-      summary: null,
-      trend: null,
-      invoices: null,
-      bookings: null,
-    },
-  });
-
   const fetchOverview = async ({ silent = false } = {}) => {
-    const hasToken = Boolean(Auth.getToken());
-    const isAdmin = Boolean(Auth.getProfile()?.data?.adminFlag);
-    setDebugState((prev) => ({
-      ...prev,
-      hasToken,
-      isAdmin,
-      loaderStarted: true,
-      failed: false,
-    }));
-    console.info('[AccountingOverview] loader start', {
-      silent,
-      basis,
-      hasToken,
-      isAdmin,
-    });
     if (silent) {
       setRefreshing(true);
     } else {
@@ -121,24 +90,6 @@ export default function AccountingOverview() {
         authFetch('/api/invoices'),
         authFetch('/api/bookings'),
       ]);
-      const statuses = {
-        summary: summaryRes.status,
-        trend: trendRes.status,
-        invoices: invoicesRes.status,
-        bookings: bookingsRes.status,
-      };
-      setDebugState((prev) => ({
-        ...prev,
-        statuses,
-        failed: !summaryRes.ok || !trendRes.ok || !invoicesRes.ok || !bookingsRes.ok,
-      }));
-      console.info('[AccountingOverview] loader response statuses', {
-        summary: summaryRes.status,
-        trend: trendRes.status,
-        invoices: invoicesRes.status,
-        bookings: bookingsRes.status,
-      });
-
       const [summaryJson, trendJson, invoicesJson, bookingsJson] = await Promise.all([
         summaryRes.json(),
         trendRes.json(),
@@ -156,7 +107,6 @@ export default function AccountingOverview() {
       setInvoices(Array.isArray(invoicesJson) ? invoicesJson : []);
       setBookings(Array.isArray(bookingsJson) ? bookingsJson : []);
     } catch (err) {
-      setDebugState((prev) => ({ ...prev, failed: true }));
       console.error('[AccountingOverview] loader failure', err);
       setError(err.message || 'Failed to load accounting overview');
     } finally {
@@ -164,28 +114,6 @@ export default function AccountingOverview() {
       setRefreshing(false);
     }
   };
-
-  useEffect(() => {
-    const isMobileViewport =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(max-width: 767.98px)').matches;
-    const hasToken = Boolean(Auth.getToken());
-    const isAdmin = Boolean(Auth.getProfile()?.data?.adminFlag);
-    setDebugState((prev) => ({
-      ...prev,
-      mounted: true,
-      isMobileViewport,
-      hasToken,
-      isAdmin,
-    }));
-    console.info('[AccountingOverview] mounted', {
-      basis,
-      isMobileViewport,
-      hasToken,
-      isAdmin,
-    });
-  }, []); // mount trace only
 
   useEffect(() => {
     fetchOverview();
@@ -228,24 +156,6 @@ export default function AccountingOverview() {
 
   return (
     <Container fluid className="py-3 px-1">
-      <Card className="mb-3 border-warning">
-        <Card.Body className="py-2 px-3">
-          <small className="d-block">
-            <strong>Accounting Debug</strong> · mounted: {String(debugState.mounted)} · mobile:{' '}
-            {String(debugState.isMobileViewport)} · token: {String(debugState.hasToken)} · admin:{' '}
-            {String(debugState.isAdmin)}
-          </small>
-          <small className="d-block">
-            loader started: {String(debugState.loaderStarted)} · failed: {String(debugState.failed)}
-          </small>
-          <small className="d-block">
-            statuses → summary: {debugState.statuses.summary ?? 'n/a'}, trend:{' '}
-            {debugState.statuses.trend ?? 'n/a'}, invoices: {debugState.statuses.invoices ?? 'n/a'},
-            bookings: {debugState.statuses.bookings ?? 'n/a'}
-          </small>
-        </Card.Body>
-      </Card>
-
       <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
         <div>
           <h3 className="mb-1">Accounting Overview</h3>

--- a/client/src/components/Pages/Management/BookingDashboard.jsx
+++ b/client/src/components/Pages/Management/BookingDashboard.jsx
@@ -19,7 +19,6 @@ import {
   CartesianGrid,
 } from 'recharts';
 import BookingCalendar from '/src/components/Pages/Management/BookingCalendar';
-import Auth from '/src/utils/auth';
 import { authFetch } from '/src/utils/authFetch';
 
 function normalizeStatus(status) {
@@ -36,39 +35,11 @@ export default function BookingDashboard() {
   const [highlightBookingId, setHighlightBookingId] = useState(null);
   const [showActionCenter, setShowActionCenter] = useState(false);
   const [alertPage, setAlertPage] = useState(1);
-  const [debugState, setDebugState] = useState({
-    mounted: false,
-    isMobileViewport: false,
-    hasToken: false,
-    isAdmin: false,
-    bookingsLoader: { started: false, status: null, failed: false },
-    customersLoader: { started: false, status: null, failed: false },
-  });
   const alertsPerPage = 5;
 
   const fetchBookings = async () => {
     try {
-      const hasToken = Boolean(Auth.getToken());
-      const isAdmin = Boolean(Auth.getProfile()?.data?.adminFlag);
-      setDebugState((prev) => ({
-        ...prev,
-        hasToken,
-        isAdmin,
-        bookingsLoader: { started: true, status: null, failed: false },
-      }));
-      console.info('[BookingDashboard] bookings loader start', {
-        hasToken,
-        isAdmin,
-      });
       const res = await authFetch('/api/bookings');
-      setDebugState((prev) => ({
-        ...prev,
-        bookingsLoader: { started: true, status: res.status, failed: !res.ok },
-      }));
-      console.info('[BookingDashboard] bookings loader response', {
-        status: res.status,
-        ok: res.ok,
-      });
       if (!res.ok) throw new Error('Failed to fetch bookings');
       const data = await res.json();
       // filter out data that is hidden
@@ -101,48 +72,9 @@ export default function BookingDashboard() {
   //   computeAlerts(bookings);
   // }, []);
   useEffect(() => {
-  const isMobileViewport =
-    typeof window !== 'undefined' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(max-width: 767.98px)').matches;
-  const hasToken = Boolean(Auth.getToken());
-  const isAdmin = Boolean(Auth.getProfile()?.data?.adminFlag);
-  setDebugState((prev) => ({
-    ...prev,
-    mounted: true,
-    isMobileViewport,
-    hasToken,
-    isAdmin,
-  }));
-  console.info('[BookingDashboard] mounted', {
-    isMobileViewport,
-    hasToken,
-    isAdmin,
-  });
-
   const fetchCustomers = async () => {
     try {
-      const customerHasToken = Boolean(Auth.getToken());
-      const customerIsAdmin = Boolean(Auth.getProfile()?.data?.adminFlag);
-      setDebugState((prev) => ({
-        ...prev,
-        hasToken: customerHasToken,
-        isAdmin: customerIsAdmin,
-        customersLoader: { started: true, status: null, failed: false },
-      }));
-      console.info('[BookingDashboard] customers loader start', {
-        hasToken: customerHasToken,
-        isAdmin: customerIsAdmin,
-      });
       const res = await authFetch('/api/customers');
-      setDebugState((prev) => ({
-        ...prev,
-        customersLoader: { started: true, status: res.status, failed: !res.ok },
-      }));
-      console.info('[BookingDashboard] customers loader response', {
-        status: res.status,
-        ok: res.ok,
-      });
       if (!res.ok) throw new Error('Failed to fetch customers');
       const data = await res.json();
       setCustomers(data);
@@ -546,25 +478,6 @@ export default function BookingDashboard() {
 
   return (
     <Container fluid className="py-4">
-      <Card className="mb-3 border-warning">
-        <Card.Body className="py-2 px-3">
-          <small className="d-block">
-            <strong>Booking Debug</strong> · mounted: {String(debugState.mounted)} · mobile:{' '}
-            {String(debugState.isMobileViewport)} · token: {String(debugState.hasToken)} · admin:{' '}
-            {String(debugState.isAdmin)}
-          </small>
-          <small className="d-block">
-            customers loader: started {String(debugState.customersLoader.started)} · status:{' '}
-            {debugState.customersLoader.status ?? 'n/a'} · failed:{' '}
-            {String(debugState.customersLoader.failed)}
-          </small>
-          <small className="d-block">
-            bookings loader: started {String(debugState.bookingsLoader.started)} · status:{' '}
-            {debugState.bookingsLoader.status ?? 'n/a'} · failed: {String(debugState.bookingsLoader.failed)}
-          </small>
-        </Card.Body>
-      </Card>
-
       {/* KPI Cards */}
       <Row className="mb-4">
         <Col md={4}>


### PR DESCRIPTION
### Motivation
- Mobile behavior is stable and the temporary on-screen debug panels that were added for mobile troubleshooting should be removed to avoid exposing internal debug state to users.

### Description
- Removed the Booking Debug card and all associated `debugState` and debug wiring from `client/src/components/Pages/Management/BookingDashboard.jsx` while preserving booking and customer loading logic.
- Removed the Accounting Debug card and associated `debugState` and debug wiring from `client/src/components/Pages/Dashboards/AccountingOverview.jsx` while preserving accounting data fetch/render behavior.
- Cleaned up the debug-oriented `Auth.getToken()`/`Auth.getProfile()` usage and `console.info` traces that were only driving the on-screen panels, keeping `authFetch` and error logging intact.

### Testing
- Ran `cd client && npm run build`, and the frontend build completed successfully.
- Verified the modified files compile as part of the build and that existing data-loading flows remain (no automated unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95ce6b3dc8329a08d22579e451bcb)