### PR TITLE
Revamp About Us into mobile-first conversion landing page

### DIFF
--- a/client/src/assets/css/about-us.css
+++ b/client/src/assets/css/about-us.css
@@ -1,0 +1,102 @@
+.about-us-page {
+  background: var(--cleanar-surface);
+}
+
+.about-us-hero {
+  background: linear-gradient(180deg, rgba(0, 165, 206, 0.08) 0%, rgba(137, 201, 127, 0.08) 100%);
+}
+
+.about-us-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--primary-color);
+}
+
+.about-us-title {
+  color: var(--text-cleanar-color);
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  line-height: 1.2;
+  font-weight: 800;
+}
+
+.about-us-subtitle,
+.about-us-body-copy {
+  color: var(--text-cleanar-color);
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.about-us-section-title {
+  color: var(--text-cleanar-color);
+  font-weight: 800;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.about-us-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+}
+
+.about-us-trust-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.about-us-trust-list li {
+  background: rgba(0, 165, 206, 0.1);
+  border: 1px solid rgba(0, 165, 206, 0.18);
+  border-radius: 999px;
+  color: var(--text-cleanar-color);
+  font-weight: 600;
+  font-size: 0.92rem;
+  padding: 0.45rem 0.75rem;
+  text-align: center;
+}
+
+.about-us-icon-wrap,
+.about-us-icon-inline {
+  color: var(--primary-color);
+  font-size: 1.1rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 165, 206, 0.1);
+}
+
+.about-us-area-list {
+  margin: 0;
+  padding-left: 1rem;
+  columns: 1;
+}
+
+.about-us-area-list li {
+  margin-bottom: 0.35rem;
+  color: var(--text-cleanar-color);
+}
+
+.about-us-final-cta {
+  background: linear-gradient(180deg, rgba(0, 165, 206, 0.08) 0%, rgba(255, 255, 255, 0.9) 100%);
+}
+
+@media (min-width: 576px) {
+  .about-us-trust-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 992px) {
+  .about-us-area-list {
+    columns: 2;
+  }
+}

--- a/client/src/components/Pages/Navigation/AboutUs.jsx
+++ b/client/src/components/Pages/Navigation/AboutUs.jsx
@@ -1,38 +1,27 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { Container, Row, Col, Card, CardBody, Button } from "reactstrap";
 import {
-  Row,
-  Col,
-  Card,
-  CardBody,
-  CardTitle,
-  CardText,
-  CardHeader,
-  ListGroup,
-  ListGroupItem,
-  Container,
-  Button,
-} from "reactstrap";
-import { Image } from "react-bootstrap";
-import WhyChooseUs from "/src/components/Pages/Landing/WhyChooseUs";
-import {
+  FaCheckCircle,
+  FaHandshake,
+  FaStar,
   FaUsers,
   FaLeaf,
-  FaAward,
-  FaClock,
-  FaCheckCircle,
+  FaClipboardCheck,
+  FaComments,
+  FaTools,
+  FaBuilding,
 } from "react-icons/fa";
-import Logo from "/src/assets/img/cleanar-logo.png";
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
-
+import "/src/assets/css/about-us.css";
 
 function AboutUsPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
   const goToQuote = () => {
-    navigate('/?scrollToQuote=true');
+    navigate("/?scrollToQuote=true");
   };
 
   useEffect(() => {
@@ -42,155 +31,169 @@ function AboutUsPage() {
     };
   }, []);
 
+  const values = t("about.values.cards", { returnObjects: true });
+  const reasons = t("about.whyChoose.points", { returnObjects: true });
+  const serviceAreas = t("about.serviceArea.locations", { returnObjects: true });
+
+  const valueIcons = [FaHandshake, FaStar, FaUsers, FaLeaf, FaCheckCircle];
+  const reasonIcons = [FaClipboardCheck, FaComments, FaStar, FaTools, FaLeaf, FaBuilding];
+
   return (
-    <div className="section pb-0 mb-0 light-bg-color-opaque">
+    <main className="about-us-page section pb-5 mb-0">
       <VisitorCounter page="aboutuspage" />
 
-      {/* Hero Banner */}
-      <Container>
-        <Row className="px-4 py-5 align-items-center">
-          <Col xs="12" md="6" className="text-center text-md-start mb-4 mb-md-0">
-            <Image
-              alt="CleanAR Solutions Logo"
-              src={Logo}
-              className="img-fluid"
-              style={{ maxWidth: "350px", transition: "transform 0.3s" }}
-              onMouseOver={(e) => (e.currentTarget.style.transform = "scale(1.05)")}
-              onMouseOut={(e) => (e.currentTarget.style.transform = "scale(1)")}
-            />
-          </Col>
-          <Col xs="12" md="6">
-            <h1 className="text-primary fw-bold mb-3">
-              {t("about.welcome_heading")}
-            </h1>
-            <p className="fs-5 text-secondary">
-              {t("about.welcome_text")} <br />
-              {t("about.partnership_text")}
-            </p>
-            <Link to="/products-and-services" className="btn btn-success mt-3">
-              {t("about.learn_more_services")}
-            </Link>
-          </Col>
-        </Row>
-      </Container>
+      <section className="about-us-hero py-5" aria-labelledby="about-us-hero-title">
+        <Container>
+          <Row className="g-4 align-items-center">
+            <Col xs="12" lg="7">
+              <p className="about-us-eyebrow mb-2">{t("about.hero.eyebrow")}</p>
+              <h1 id="about-us-hero-title" className="about-us-title mb-3">
+                {t("about.hero.title")}
+              </h1>
+              <p className="about-us-subtitle mb-4">{t("about.hero.subtitle")}</p>
+              <div className="d-flex flex-column flex-sm-row gap-2">
+                <Button onClick={goToQuote} className="primary-bg-color border-0 px-4 py-2 fw-semibold">
+                  {t("about.hero.ctaPrimary")}
+                </Button>
+                <Link to="/products-and-services" className="btn btn-outline-secondary px-4 py-2 fw-semibold">
+                  {t("about.hero.ctaSecondary")}
+                </Link>
+              </div>
+            </Col>
 
-      {/* Story / Mission Section */}
-      <Container className="my-5">
-        <Row>
-          <Col md="6">
-            <h2 className="fw-bold">{t("about.mission_title")}</h2>
-            <p className="fs-5 text-secondary">{t("about.mission_text")}</p>
-            <h2 className="fw-bold mt-4">{t("about.vision_title")}</h2>
-            <p className="fs-5 text-secondary">{t("about.vision_text")}</p>
-          </Col>
-          <Col md="6">
-            <Card className="shadow-sm border-0 bg-transparent">
-              <CardHeader className="bg-success text-white fw-bold">
-                {t("about.values_title")}
-              </CardHeader>
-              <CardBody className="bg-transparent">
-                <p className="fw-semibold">{t("about.values_intro")}</p>
-                <ul className="list-unstyled bg-transparent">
-                  {t("about.values_list", { returnObjects: true }).map(
-                    (value, idx) => (
-                      <li key={idx} className="mb-2">
-                        <FaCheckCircle className="text-success me-2" />
-                        {value}
-                      </li>
-                    )
-                  )}
-                </ul>
-              </CardBody>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
-      <Container className="my-5">
-        <Row>
-          <Col md="12" className="text-center">
-      <p className="fs-6 text-cleanar-color mt-3">{t("issa.prefix")}
-  {/* CleanAR Solutions is a proud member of */}
-  {" "}
-  <a
-    href="https://issa-canada.com/en/issa-canada-en/about-issa-canada-en"
-    target="_blank"
-    rel="noopener noreferrer"
-  >{t("issa.linkText")}
-    {/* ISSA Canada, a division of ISSA – the worldwide cleaning industry association */}
-  </a>{t("issa.suffix")}
-  {/* . This membership reflects our ongoing commitment to professional standards
-  in the cleaning industry. */}
-</p>
-          </Col>
-        </Row>
-      </Container>
-      {/* Quick Stats / Differentiators */}
-      <WhyChooseUs />
+            <Col xs="12" lg="5">
+              <Card className="about-us-card">
+                <CardBody>
+                  <ul className="about-us-trust-list" aria-label={t("about.hero.trustLabel")}>
+                    {t("about.hero.trustChips", { returnObjects: true }).map((chip) => (
+                      <li key={chip}>{chip}</li>
+                    ))}
+                  </ul>
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        </Container>
+      </section>
 
-      {/* Industries We Serve */}
-      <Container className="py-3 ">
-        <h2 className="text-center fw-bold mb-4">
-          {t("about.industries_title")}
-        </h2>
-        <Row>
-          <Col md="4" className="mb-4">
-            <Card className="h-100 shadow-sm border-0 bg-transparent">
-              <CardHeader className="bg-secondary text-white fw-bold">
-                {t("about.industries.residential.title")}
-              </CardHeader>
-              <ListGroup flush>
-                {t("about.industries.residential.items", {
-                  returnObjects: true,
-                }).map((item, idx) => (
-                  <ListGroupItem key={idx} className="bg-transparent">{item}</ListGroupItem>
-                ))}
-              </ListGroup>
-            </Card>
-          </Col>
-          <Col md="4" className="mb-4">
-            <Card className="h-100 shadow-sm border-0 bg-transparent">
-              <CardHeader className="bg-primary text-white fw-bold">
-                {t("about.industries.offices.title")}
-              </CardHeader>
-              <ListGroup flush>
-                {t("about.industries.offices.items", {
-                  returnObjects: true,
-                }).map((item, idx) => (
-                  <ListGroupItem key={idx} className="bg-transparent">{item}</ListGroupItem>
-                ))}
-              </ListGroup>
-            </Card>
-          </Col>
-          <Col md="4" className="mb-4">
-            <Card className="h-100 shadow-sm border-0 bg-transparent">
-              <CardHeader className="bg-success text-white fw-bold">
-                {t("about.industries.festivals.title")}
-              </CardHeader>
-              <ListGroup flush>
-                {t("about.industries.festivals.items", {
-                  returnObjects: true,
-                }).map((item, idx) => (
-                  <ListGroupItem key={idx} className="bg-transparent">{item}</ListGroupItem>
-                ))}
-              </ListGroup>
-            </Card>
-          </Col>
-        </Row>
-      </Container>
+      <section className="py-4" aria-labelledby="about-story-title">
+        <Container>
+          <Card className="about-us-card">
+            <CardBody className="p-4 p-md-5">
+              <h2 id="about-story-title" className="about-us-section-title mb-3">{t("about.story.title")}</h2>
+              <p className="mb-0 about-us-body-copy">{t("about.story.body")}</p>
+            </CardBody>
+          </Card>
+        </Container>
+      </section>
 
-      {/* Call to Action */}
-      <Container className="text-center py-5">
-        <h2 className="fw-bold text-dark mb-3">
-          {t("about.cta.ready")}
-        </h2>
-        <p className="text-bold mb-4">
-          {t("about.cta.focus")}
-        </p>
-        <Button onClick={goToQuote} className="btn btn-lg primary-bg-color">
-          {t("about.cta.quote")}
-        </Button>
-      </Container>
-    </div>
+      <section className="py-4" aria-labelledby="about-mission-vision-title">
+        <Container>
+          <h2 id="about-mission-vision-title" className="about-us-section-title mb-3">{t("about.missionVision.title")}</h2>
+          <Row className="g-3">
+            <Col xs="12" md="6">
+              <Card className="about-us-card h-100">
+                <CardBody className="p-4">
+                  <h3 className="h5 fw-bold">{t("about.missionVision.mission.title")}</h3>
+                  <p className="mb-0 about-us-body-copy">{t("about.missionVision.mission.body")}</p>
+                </CardBody>
+              </Card>
+            </Col>
+            <Col xs="12" md="6">
+              <Card className="about-us-card h-100">
+                <CardBody className="p-4">
+                  <h3 className="h5 fw-bold">{t("about.missionVision.vision.title")}</h3>
+                  <p className="mb-0 about-us-body-copy">{t("about.missionVision.vision.body")}</p>
+                </CardBody>
+              </Card>
+            </Col>
+          </Row>
+        </Container>
+      </section>
+
+      <section className="py-4" aria-labelledby="about-values-title">
+        <Container>
+          <h2 id="about-values-title" className="about-us-section-title mb-3">{t("about.values.title")}</h2>
+          <Row className="g-3">
+            {values.map((value, index) => {
+              const Icon = valueIcons[index] ?? FaCheckCircle;
+              return (
+                <Col xs="12" sm="6" lg="4" key={value.title}>
+                  <Card className="about-us-card h-100">
+                    <CardBody className="p-4">
+                      <div className="about-us-icon-wrap" aria-hidden="true">
+                        <Icon />
+                      </div>
+                      <h3 className="h5 fw-bold mt-3">{value.title}</h3>
+                      <p className="mb-0 about-us-body-copy">{value.description}</p>
+                    </CardBody>
+                  </Card>
+                </Col>
+              );
+            })}
+          </Row>
+        </Container>
+      </section>
+
+      <section className="py-4" aria-labelledby="about-why-title">
+        <Container>
+          <h2 id="about-why-title" className="about-us-section-title mb-3">{t("about.whyChoose.title")}</h2>
+          <Row className="g-3">
+            {reasons.map((reason, index) => {
+              const Icon = reasonIcons[index] ?? FaCheckCircle;
+              return (
+                <Col xs="12" sm="6" lg="4" key={reason}>
+                  <Card className="about-us-card h-100">
+                    <CardBody className="p-4 d-flex align-items-start gap-3">
+                      <span className="about-us-icon-inline" aria-hidden="true">
+                        <Icon />
+                      </span>
+                      <p className="mb-0 about-us-body-copy fw-semibold">{reason}</p>
+                    </CardBody>
+                  </Card>
+                </Col>
+              );
+            })}
+          </Row>
+        </Container>
+      </section>
+
+      <section className="py-4" aria-labelledby="about-service-area-title">
+        <Container>
+          <Card className="about-us-card">
+            <CardBody className="p-4 p-md-5">
+              <h2 id="about-service-area-title" className="about-us-section-title mb-3">{t("about.serviceArea.title")}</h2>
+              <p className="about-us-body-copy mb-3">{t("about.serviceArea.intro")}</p>
+              <ul className="about-us-area-list">
+                {serviceAreas.map((location) => (
+                  <li key={location}>{location}</li>
+                ))}
+              </ul>
+            </CardBody>
+          </Card>
+        </Container>
+      </section>
+
+      <section className="py-4" aria-labelledby="about-final-cta-title">
+        <Container>
+          <Card className="about-us-card about-us-final-cta text-center">
+            <CardBody className="p-4 p-md-5">
+              <h2 id="about-final-cta-title" className="about-us-section-title mb-2">{t("about.finalCta.title")}</h2>
+              <p className="about-us-body-copy mb-4">{t("about.finalCta.subtitle")}</p>
+              <div className="d-flex flex-column flex-sm-row justify-content-center gap-2">
+                <Button onClick={goToQuote} className="primary-bg-color border-0 px-4 py-2 fw-semibold">
+                  {t("about.finalCta.ctaPrimary")}
+                </Button>
+                <Link to="/products-and-services" className="btn btn-outline-secondary px-4 py-2 fw-semibold">
+                  {t("about.finalCta.ctaSecondary")}
+                </Link>
+              </div>
+              <p className="small text-muted mt-3 mb-0">{t("about.finalCta.contactHint")}</p>
+            </CardBody>
+          </Card>
+        </Container>
+      </section>
+    </main>
   );
 }
 

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -587,54 +587,95 @@
     "power_pressure_washing_button": "Get Quote for Power Washing"
   },
   "about": {
-    "welcome_heading": "Welcome to CleanAR Solutions",
-    "welcome_text": "At CleanAR Solutions, we provide professional cleaning services in Toronto and the GTA. Our focus on excellence ensures every project meets the highest standards, creating a clean and healthy environment. Whether you need residential, commercial, or carpet cleaning, we customize our approach to meet your needs. Get started by requesting a quote, or contact us for more information.",
-    "partnership_text": "We’re more than cleaners — we’re partners in creating healthier, stress-free environments.",
-    "learn_more_services": "Learn More About Our Services",
-    "mission_title": "Our Mission",
-    "mission_text": "Our mission is to transform spaces into cleaner, healthier, and more welcoming environments. We achieve this by offering customizable, high-quality cleaning services that are tailored to our clients’ needs while staying true to our commitment to sustainability and excellence.",
-    "vision_title": "Our Vision",
-    "vision_text": "Our vision is to become Toronto’s most trusted and innovative cleaning service provider, setting the standard for excellence while contributing to a cleaner, greener, and happier community.",
-    "values_title": "Our Values",
-    "values_intro": "At CleanAR Solutions, we are guided by the following values:",
-    "values_list": [
-      "Integrity: We conduct our business with honesty, transparency, and accountability.",
-      "Quality: We deliver top-tier cleaning services with attention to detail and excellence.",
-      "Customer Focus: We prioritize our clients’ unique needs, building trust through personalized solutions.",
-      "Sustainability: We promote eco-friendly cleaning practices to protect our environment.",
-      "Teamwork: We value collaboration, respect, and unity to achieve success together."
-    ],
-    "industries_title": "Professional Cleaning Services for Every Industry",
-    "industries": {
-      "residential": {
-        "title": "Residential & Multi-Family Properties",
-        "items": [
-          "Comprehensive Common Area Cleaning: Professional maintenance of apartment lobbies, hallways, stairwells, elevators, and recreational facilities to maintain property value and tenant satisfaction.",
-          "Exterior Property Maintenance: Power washing of sidewalks, entryways, courtyards, parking areas, and building exteriors to enhance curb appeal and safety.",
-          "Waste Management Services: Reliable trash collection, recycling management, and proper disposal of residential waste with eco-friendly practices."
-        ]
+    "hero": {
+      "eyebrow": "About CleanAR Solutions",
+      "title": "Cleaning Services Built on Trust, Quality, and Care",
+      "subtitle": "CleanAR Solutions is a Toronto and GTA professional cleaning company delivering personalized service for homes and businesses.",
+      "ctaPrimary": "Request a Quote",
+      "ctaSecondary": "Explore Our Services",
+      "trustLabel": "Trust highlights",
+      "trustChips": [
+        "Toronto & GTA",
+        "Residential + Commercial",
+        "Eco-conscious options",
+        "Flexible scheduling"
+      ]
+    },
+    "story": {
+      "title": "Who We Are",
+      "body": "Founded in 2024, CleanAR Solutions is built on small-business care backed by professional systems. We bring reliable communication, detailed execution, and customized plans to every client so each space feels fresh, spotless, and ready for what comes next."
+    },
+    "missionVision": {
+      "title": "Mission and Vision",
+      "mission": {
+        "title": "Our Mission",
+        "body": "To deliver reliable, high-quality cleaning services tailored to each client’s needs, creating fresh and spotless spaces every time."
       },
-      "offices": {
-        "title": "Office Buildings & Commercial Spaces",
-        "items": [
-          "Daily Office Cleaning Services: Thorough sanitization of workstations, conference rooms, break areas, and reception areas to maintain a healthy, productive workplace environment.",
-          "Professional Floor Care: Expert sweeping, mopping, vacuuming, and floor polishing services for all surface types including carpet, hardwood, and tile flooring.",
-          "Restroom Sanitization: Complete disinfection and deep cleaning of office bathrooms, including supply restocking and odor elimination for employee health and comfort."
-        ]
-      },
-      "festivals": {
-        "title": "Event & Festival Cleaning Services",
-        "items": [
-          "Pre-Event Site Preparation: Complete venue cleaning and sanitization before events, including grounds cleanup, vendor area preparation, and waste station setup.",
-          "During-Event Maintenance: Continuous cleaning services throughout festivals including restroom maintenance, food service area sanitization, and real-time waste management.",
-          "Post-Event Restoration: Comprehensive venue cleanup after events including debris removal, deep sanitization, and complete site restoration to original condition."
-        ]
+      "vision": {
+        "title": "Our Vision",
+        "body": "To set the standard for cleaning services in Toronto by combining quality, reliability, and innovation while building a cleaner and more sustainable community."
       }
     },
-    "cta": {
-      "ready": "Ready for a cleaner, healthier space?",
-      "focus": "Let us take care of the mess — you focus on what matters most.",
-      "quote": "Get Your Free Quote"
+    "values": {
+      "title": "Our Core Values",
+      "cards": [
+        {
+          "title": "Integrity",
+          "description": "We lead with honesty, transparency, and accountability in every interaction."
+        },
+        {
+          "title": "Quality",
+          "description": "We focus on details and consistent excellence in every service visit."
+        },
+        {
+          "title": "Customer Focus",
+          "description": "We build personalized cleaning solutions around each client’s priorities."
+        },
+        {
+          "title": "Sustainability",
+          "description": "We use eco-conscious practices that support healthy spaces and the environment."
+        },
+        {
+          "title": "Teamwork",
+          "description": "We work with collaboration, respect, and unity to deliver dependable results."
+        }
+      ]
+    },
+    "whyChoose": {
+      "title": "Why Choose CleanAR Solutions",
+      "points": [
+        "Customized cleaning plans for your schedule and priorities",
+        "Reliable communication from booking to follow-up",
+        "Detail-oriented service with consistent quality control",
+        "Professional equipment and trusted cleaning supplies",
+        "Eco-conscious options for healthier spaces",
+        "Flexible support for both residential and commercial needs"
+      ]
+    },
+    "serviceArea": {
+      "title": "Proudly Serving Toronto and the GTA",
+      "intro": "We support clients across Toronto and nearby GTA communities, including:",
+      "locations": [
+        "Downtown Toronto",
+        "East York",
+        "North York",
+        "Midtown",
+        "Scarborough",
+        "Etobicoke",
+        "Mississauga",
+        "Markham",
+        "Richmond Hill",
+        "Pickering",
+        "Vaughan",
+        "Oakville"
+      ]
+    },
+    "finalCta": {
+      "title": "Ready for a cleaner, fresher space?",
+      "subtitle": "Let our team build the right cleaning plan for your home, office, or property.",
+      "ctaPrimary": "Request a Quote",
+      "ctaSecondary": "Explore Our Services",
+      "contactHint": "Prefer to speak with our team first? Use our contact options in the footer."
     }
   },
   "navbar": {

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -575,54 +575,95 @@
     "power_pressure_washing_button": "Cotizar limpieza a presión"
   },
   "about": {
-    "welcome_heading": "Bienvenido a CleanAR Solutions",
-    "welcome_text": "En CleanAR Solutions ofrecemos servicios profesionales de limpieza en Toronto y el GTA. Nuestro enfoque en la excelencia garantiza que cada proyecto cumpla con los más altos estándares, creando un entorno limpio y saludable. Ya sea que necesite limpieza residencial, comercial o de alfombras, adaptamos nuestro enfoque para satisfacer sus necesidades. Solicite una cotización o contáctenos para más información.",
-    "partnership_text": "Más que limpiadores, somos socios en la creación de entornos más saludables y sin estrés.",
-    "learn_more_services": "Conozca más sobre nuestros servicios",
-    "mission_title": "Nuestra Misión",
-    "mission_text": "Nuestra misión es transformar espacios en entornos más limpios, saludables y acogedores. Lo logramos ofreciendo servicios de limpieza personalizables y de alta calidad, adaptados a las necesidades de nuestros clientes y comprometidos con la sostenibilidad y la excelencia.",
-    "vision_title": "Nuestra Visión",
-    "vision_text": "Nuestra visión es convertirnos en el proveedor de servicios de limpieza más confiable e innovador de Toronto, estableciendo el estándar de excelencia y contribuyendo a una comunidad más limpia, ecológica y feliz.",
-    "values_title": "Nuestros Valores",
-    "values_intro": "En CleanAR Solutions nos guiamos por los siguientes valores:",
-    "values_list": [
-      "Integridad: Actuamos con honestidad, transparencia y responsabilidad.",
-      "Calidad: Brindamos servicios de limpieza de alto nivel con atención al detalle y excelencia.",
-      "Enfoque en el cliente: Priorizamos las necesidades únicas de nuestros clientes con soluciones personalizadas.",
-      "Sostenibilidad: Promovemos prácticas de limpieza ecológicas para proteger el medio ambiente.",
-      "Trabajo en equipo: Valoramos la colaboración, el respeto y la unidad para lograr el éxito juntos."
-    ],
-    "industries_title": "Servicios Profesionales de Limpieza para cada Industrias",
-    "industries": {
-      "residential": {
-        "title": "Propiedades Residenciales y unidades multi-familiares",
-        "items": [
-          "Limpieza general de áreas comunes: Mantenimiento profesional de vestíbulos, pasillos, escaleras, ascensores y áreas recreativas de apartamentos para mantener el valor de la propiedad y la satisfacción de los inquilinos.",
-          "Mantenimiento exterior de la propiedad: Limpieza a presión de aceras, entradas, patios, áreas de estacionamiento y exteriores de edificios para mejorar el atractivo y la seguridad.",
-          "Servicios de gestión de residuos: Recolección confiable de basura, gestión de reciclaje y eliminación adecuada de desechos residenciales con prácticas ecológicas."
-        ]
+    "hero": {
+      "eyebrow": "Sobre CleanAR Solutions",
+      "title": "Servicios de limpieza basados en confianza, calidad y cuidado",
+      "subtitle": "CleanAR Solutions es una empresa profesional de limpieza en Toronto y GTA que ofrece servicios personalizados para hogares y negocios.",
+      "ctaPrimary": "Solicitar cotización",
+      "ctaSecondary": "Explorar servicios",
+      "trustLabel": "Puntos de confianza",
+      "trustChips": [
+        "Toronto y GTA",
+        "Residencial + comercial",
+        "Opciones ecológicas",
+        "Horarios flexibles"
+      ]
+    },
+    "story": {
+      "title": "Quiénes somos",
+      "body": "Fundada en 2024, CleanAR Solutions combina atención cercana de negocio local con sistemas profesionales. Ofrecemos comunicación confiable, ejecución detallada y planes personalizados para que cada espacio se vea fresco y impecable."
+    },
+    "missionVision": {
+      "title": "Misión y visión",
+      "mission": {
+        "title": "Nuestra misión",
+        "body": "Brindar servicios de limpieza confiables y de alta calidad, adaptados a las necesidades de cada cliente, creando espacios frescos e impecables en cada visita."
       },
-      "offices": {
-        "title": "Edificios de oficinas y espacios comerciales",
-        "items": [
-          "Servicios de limpieza de oficinas diarias: Desinfección completa de estaciones de trabajo, salas de conferencias, áreas de descanso y áreas de recepción para mantener un ambiente de trabajo saludable y productivo.",
-          "Cuidado profesional de suelos: Servicios expertos de barrido, fregado, aspirado y pulido de suelos para todo tipo de superficies, incluyendo alfombra, madera y baldosas.",
-          "Desinfección de baños: Desinfección completa y limpieza profunda de baños de oficina, incluyendo reposición de suministros y eliminación de olores para la salud y comodidad de los empleados."
-        ]
-      },
-      "festivals": {
-        "title": "Servicios de limpiezas de eventos y festivales",
-        "items": [
-          "Preparación del sitio antes del evento: Limpieza y desinfección completa del lugar antes de los eventos, incluyendo la limpieza de terrenos, la preparación de áreas para proveedores y la instalación de estaciones de residuos.",
-          "Mantenimiento durante el evento: Servicios de limpieza continua durante los festivales, incluyendo el mantenimiento de baños, la desinfección de áreas de servicio de alimentos y la gestión de residuos en tiempo real.",
-          "Restauración posterior al evento: Limpieza integral del lugar después de los eventos, incluyendo la eliminación de escombros, la desinfección profunda y la restauración completa del sitio a su estado original."
-        ]
+      "vision": {
+        "title": "Nuestra visión",
+        "body": "Ser el estándar de servicios de limpieza en Toronto, combinando calidad, confiabilidad e innovación para construir una comunidad más limpia y sostenible."
       }
     },
-    "cta": {
-      "ready": "Listo para un espacio más limpio y saludable?",
-      "focus": "Déjanos encargarnos del desorden, tú concéntrate en lo que más importa.",
-      "quote": "Obtén tu cotización gratuita"
+    "values": {
+      "title": "Nuestros valores",
+      "cards": [
+        {
+          "title": "Integridad",
+          "description": "Actuamos con honestidad, transparencia y responsabilidad."
+        },
+        {
+          "title": "Calidad",
+          "description": "Cuidamos cada detalle para mantener una excelencia constante."
+        },
+        {
+          "title": "Enfoque en el cliente",
+          "description": "Creamos soluciones personalizadas según las necesidades de cada cliente."
+        },
+        {
+          "title": "Sostenibilidad",
+          "description": "Aplicamos prácticas ecológicas para proteger a las personas y al entorno."
+        },
+        {
+          "title": "Trabajo en equipo",
+          "description": "Colaboramos con respeto y unidad para lograr resultados confiables."
+        }
+      ]
+    },
+    "whyChoose": {
+      "title": "Por qué elegir CleanAR Solutions",
+      "points": [
+        "Planes de limpieza personalizados",
+        "Comunicación confiable",
+        "Servicio orientado al detalle",
+        "Equipos e insumos profesionales",
+        "Enfoque ecológico",
+        "Flexibilidad residencial y comercial"
+      ]
+    },
+    "serviceArea": {
+      "title": "Servicio en Toronto y GTA",
+      "intro": "Atendemos clientes en Toronto y comunidades cercanas del GTA, incluyendo:",
+      "locations": [
+        "Downtown Toronto",
+        "East York",
+        "North York",
+        "Midtown",
+        "Scarborough",
+        "Etobicoke",
+        "Mississauga",
+        "Markham",
+        "Richmond Hill",
+        "Pickering",
+        "Vaughan",
+        "Oakville"
+      ]
+    },
+    "finalCta": {
+      "title": "¿Listo para un espacio más limpio y fresco?",
+      "subtitle": "Creamos el plan de limpieza ideal para su hogar, oficina o propiedad.",
+      "ctaPrimary": "Solicitar cotización",
+      "ctaSecondary": "Explorar servicios",
+      "contactHint": "¿Prefiere hablar primero con nuestro equipo? Use las opciones de contacto en el pie de página."
     }
   },
   "navbar": {

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -574,54 +574,95 @@
     "power_pressure_washing_button": "Ajouter le nettoyage haute pression au devis"
   },
   "about": {
-    "welcome_heading": "Bienvenue chez CleanAR Solutions",
-    "welcome_text": "Chez CleanAR Solutions, nous offrons des services de nettoyage professionnels à Toronto et dans la région du Grand Toronto. Notre engagement envers l'excellence garantit que chaque projet respecte les normes les plus élevées, créant ainsi un environnement propre et sain. Que vous ayez besoin de services résidentiels, commerciaux ou de nettoyage de tapis, nous adaptons notre approche à vos besoins. Commencez en demandant un devis, ou contactez-nous pour plus d'informations.",
-    "partnership_text": "Nous ne sommes pas seulement des nettoyeurs, nous sommes des partenaires dans la création d'environnements plus sains et sans stress.",
-    "learn_more_services": "En savoir plus sur nos services",
-    "mission_title": "Notre Mission",
-    "mission_text": "Notre mission est de transformer les espaces en environnements plus propres, plus sains et plus accueillants. Nous y parvenons en offrant des services de nettoyage personnalisables et de haute qualité, adaptés aux besoins de nos clients tout en respectant notre engagement envers la durabilité et l'excellence.",
-    "vision_title": "Notre Vision",
-    "vision_text": "Notre vision est de devenir le fournisseur de services de nettoyage le plus fiable et innovant à Toronto, en établissant une norme d'excellence tout en contribuant à une communauté plus propre, plus verte et plus heureuse.",
-    "values_title": "Nos Valeurs",
-    "values_intro": "Chez CleanAR Solutions, nous sommes guidés par les valeurs suivantes :",
-    "values_list": [
-      "Intégrité: Nous menons nos activités avec honnêteté, transparence et responsabilité.",
-      "Qualité: Nous offrons des services de nettoyage de premier ordre avec souci du détail et excellence.",
-      "Orientation client: Nous mettons les besoins uniques de nos clients au premier plan, en bâtissant la confiance grâce à des solutions personnalisées.",
-      "Durabilité: Nous encourageons des pratiques de nettoyage respectueuses de l'environnement.",
-      "Travail d'équipe: Nous valorisons la collaboration, le respect et l'unité pour réussir ensemble."
-    ],
-    "industries_title": "Services de Nettoyage Professionnels pour Tous les Secteurs",
-    "industries": {
-      "residential": {
-        "title": "Propriétés Résidentielles et Multi-Familiales",
-        "items": [
-          "Nettoyage Complet des Espaces Communs: Entretien professionnel des halls d'entrée, couloirs, escaliers, ascenseurs et installations récréatives pour maintenir la valeur de la propriété et la satisfaction des locataires.",
-          "Entretien des Espaces Extérieurs: Nettoyage haute pression des trottoirs, entrées, cours, parkings et façades de bâtiments pour améliorer l'attrait et la sécurité.",
-          "Services de Gestion des Déchets: Collecte fiable des déchets, gestion du recyclage et élimination appropriée des déchets résidentiels avec des pratiques respectueuses de l'environnement."
-        ]
+    "hero": {
+      "eyebrow": "À propos de CleanAR Solutions",
+      "title": "Des services de nettoyage fondés sur la confiance, la qualité et le soin",
+      "subtitle": "CleanAR Solutions est une entreprise professionnelle de nettoyage à Toronto et dans le GTA, avec un service personnalisé pour les résidences et les entreprises.",
+      "ctaPrimary": "Demander un devis",
+      "ctaSecondary": "Découvrir nos services",
+      "trustLabel": "Éléments de confiance",
+      "trustChips": [
+        "Toronto et GTA",
+        "Résidentiel + commercial",
+        "Options écoresponsables",
+        "Horaires flexibles"
+      ]
+    },
+    "story": {
+      "title": "Qui nous sommes",
+      "body": "Fondée en 2024, CleanAR Solutions offre l'attention d'une petite entreprise avec des systèmes professionnels. Nous assurons une communication fiable, une exécution minutieuse et des plans sur mesure pour que chaque espace reste frais et impeccable."
+    },
+    "missionVision": {
+      "title": "Mission et vision",
+      "mission": {
+        "title": "Notre mission",
+        "body": "Offrir des services de nettoyage fiables et de haute qualité, adaptés aux besoins de chaque client, afin de créer des espaces frais et impeccables à chaque intervention."
       },
-      "offices": {
-        "title": "Bâtiments de Bureau et Espaces Commerciaux",
-        "items": [
-          "Services de Nettoyage Quotidien des Bureaux: Désinfection approfondie des postes de travail, salles de conférence, espaces de pause et zones d'accueil pour maintenir un environnement de travail sain et productif.",
-          "Entretien Professionnel des Sols: Services d'expertise en balayage, nettoyage humide, aspiration et polissage des sols pour tous les types de surfaces, y compris les moquettes, les parquets et les carrelages.",
-          "Désinfection des Sanitaires: Nettoyage en profondeur et désinfection des salles de bains de bureau, y compris le réapprovisionnement des fournitures et l'élimination des odeurs pour la santé et le confort des employés."
-        ]
-      },
-      "festivals": {
-        "title": "Services de Nettoyage pour Événements et Festivals",
-        "items": [
-          "Préparation du Site Avant l'Événement: Nettoyage complet et désinfection du lieu avant les événements, y compris le nettoyage des terrains, la préparation des zones de vendeurs et la mise en place des stations de déchets.",
-          "Maintenance Pendant l'Événement: Services de nettoyage continus tout au long des festivals, y compris l'entretien des toilettes, la désinfection des zones de restauration et la gestion des déchets en temps réel.",
-          "Restauration Après l'Événement: Nettoyage complet du lieu après les événements, y compris l'enlèvement des débris, la désinfection en profondeur et la restauration complète du site à son état d'origine."
-        ]
+      "vision": {
+        "title": "Notre vision",
+        "body": "Établir la norme des services de nettoyage à Toronto en combinant qualité, fiabilité et innovation, tout en bâtissant une communauté plus propre et durable."
       }
     },
-    "cta": {
-      "ready": "Prêt pour un espace plus propre et plus sain?",
-      "focus": "Laissez-nous nous occuper du désordre, concentrez-vous sur ce qui compte le plus.",
-      "quote": "Obtenez votre devis gratuit"
+    "values": {
+      "title": "Nos valeurs",
+      "cards": [
+        {
+          "title": "Intégrité",
+          "description": "Nous agissons avec honnêteté, transparence et responsabilité."
+        },
+        {
+          "title": "Qualité",
+          "description": "Nous visons l'excellence constante avec une grande attention aux détails."
+        },
+        {
+          "title": "Orientation client",
+          "description": "Nous adaptons nos solutions aux besoins de chaque client."
+        },
+        {
+          "title": "Durabilité",
+          "description": "Nous appliquons des pratiques écoresponsables pour protéger les clients et l'environnement."
+        },
+        {
+          "title": "Esprit d'équipe",
+          "description": "Nous collaborons avec respect et unité pour livrer des résultats fiables."
+        }
+      ]
+    },
+    "whyChoose": {
+      "title": "Pourquoi choisir CleanAR Solutions",
+      "points": [
+        "Plans de nettoyage personnalisés",
+        "Communication fiable",
+        "Service axé sur les détails",
+        "Équipement et produits professionnels",
+        "Approche écoresponsable",
+        "Flexibilité résidentielle et commerciale"
+      ]
+    },
+    "serviceArea": {
+      "title": "Service à Toronto et dans le GTA",
+      "intro": "Nous accompagnons nos clients à Toronto et dans les communautés voisines du GTA, notamment :",
+      "locations": [
+        "Downtown Toronto",
+        "East York",
+        "North York",
+        "Midtown",
+        "Scarborough",
+        "Etobicoke",
+        "Mississauga",
+        "Markham",
+        "Richmond Hill",
+        "Pickering",
+        "Vaughan",
+        "Oakville"
+      ]
+    },
+    "finalCta": {
+      "title": "Prêt pour un espace plus propre et plus frais ?",
+      "subtitle": "Nous créons le plan de nettoyage adapté à votre maison, bureau ou propriété.",
+      "ctaPrimary": "Demander un devis",
+      "ctaSecondary": "Découvrir nos services",
+      "contactHint": "Vous préférez parler à notre équipe d'abord ? Utilisez les options de contact dans le pied de page."
     }
   },
   "navbar": {

--- a/client/src/seo/routeMeta.mjs
+++ b/client/src/seo/routeMeta.mjs
@@ -40,9 +40,9 @@ export const ROUTE_META = {
       "cleaning services toronto, professional cleaning, residential cleaning, commercial cleaning, carpet cleaning, upholstery cleaning, CleanAR Solutions",
   },
   "/about-us": {
-    title: "About CleanAR Solutions | Toronto & GTA Cleaning Team",
+    title: "About CleanAR Solutions | Cleaning Services in Toronto & GTA",
     description:
-      "Learn about CleanAR Solutions, our mission, and our commitment to reliable, high-quality cleaning services across Toronto and the GTA.",
+      "Learn about CleanAR Solutions, a Toronto-based cleaning company providing residential, commercial, deep cleaning, move-in/move-out, carpet and upholstery cleaning services across the GTA.",
   },
   "/products-and-services": {
     title: "Cleaning Services | Residential & Commercial | CleanAR Solutions",


### PR DESCRIPTION
### Motivation
- Turn the existing About page into a high-converting, mobile-first landing section that builds trust and routes visitors to quote requests while preserving the current React/Reactstrap/i18n architecture. 
- Emphasize CleanAR's Toronto/GTA positioning, services, mission, vision, and values while keeping the brand warm, modern, and service-focused. 
- Preserve existing routing, SEO/meta handling, and translation patterns so the change is reviewable and low-risk. 

### Description
- Replaced the About page component with a semantic, conversion-focused layout that includes Hero (primary and secondary CTAs), Story (Who We Are, founded 2024), Mission & Vision cards (responsive), Values cards (5 items with icons), Why Choose benefits, Service-area list, and a Final CTA that routes to `/?scrollToQuote=true` and `/products-and-services`.
- Added a scoped stylesheet `client/src/assets/css/about-us.css` that follows existing theme tokens and responsive/card patterns for a polished mobile-first experience.
- Updated i18n `about` keys and content in `client/src/locales/en/translation.json`, `client/src/locales/es/translation.json`, and `client/src/locales/fr/translation.json` to match the new structure and copy.
- Updated `/about-us` SEO metadata in `client/src/seo/routeMeta.mjs` to the requested title and description while keeping the existing `MetaTags` pattern intact.
- Files changed: `client/src/components/Pages/Navigation/AboutUs.jsx`, `client/src/assets/css/about-us.css` (new), `client/src/locales/en/translation.json`, `client/src/locales/es/translation.json`, `client/src/locales/fr/translation.json`, and `client/src/seo/routeMeta.mjs`.

### Testing
- Ran the frontend production build with `npm run build` from the `client/` directory and the build completed successfully (production build and marketing prerender steps ran without errors). 
- The prerender step generated marketing routes including `about-us/index.html`, indicating the updated route is included in static output. 
- No additional automated unit tests were present/modified for this change and no test failures were produced by the build run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae621e1a08329b3fd062cd9d3ce4c)