### PR TITLE
Revamp Services page with standardized high-conversion structure

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "dev": "vite",
     "build": "vite build && node ./scripts/prerender-marketing-routes.mjs",
     "preview": "vite preview",
+    "screenshot:services": "node ./scripts/capture-services-screenshots.mjs",
     "start": "vite",
     "media:bootstrap": "bash ./scripts/bootstrap-media-tooling.sh",
     "media:optimize": "bash ./scripts/optimize-images.sh",

--- a/client/scripts/capture-services-screenshots.mjs
+++ b/client/scripts/capture-services-screenshots.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.SCREENSHOT_BASE_URL || 'http://127.0.0.1:4173';
+const outputDir = process.env.SCREENSHOT_OUTPUT_DIR || '/tmp/screenshots/cleanar-services';
+
+const targets = [
+  { name: 'services-desktop', route: '/products-and-services', viewport: { width: 1440, height: 1200 } },
+  { name: 'services-mobile', route: '/products-and-services', viewport: { width: 390, height: 844 } }
+];
+
+const run = async () => {
+  await fs.mkdir(outputDir, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    for (const target of targets) {
+      const page = await browser.newPage({ viewport: target.viewport });
+      const url = new URL(target.route, baseUrl).toString();
+      await page.goto(url, { waitUntil: 'networkidle', timeout: 45000 });
+      await page.waitForTimeout(1200);
+      await page.screenshot({
+        path: path.join(outputDir, `${target.name}.png`),
+        fullPage: true
+      });
+      await page.close();
+      console.log(`Saved ${target.name}.png from ${url}`);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`Screenshots written to ${outputDir}`);
+};
+
+run().catch((error) => {
+  console.error('Failed to capture service screenshots. Ensure the app is running and Playwright browsers are installed.');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2978,7 +2978,7 @@ html {
   padding: 1.3rem;
 }
 
-.products-services-page .services-mobile-toggle {
+.products-services-page .services-mobile-section-toggle {
   width: 100%;
   border: 1px solid var(--cleanar-surface-border);
   background: color-mix(in srgb, var(--light-color) 45%, white);
@@ -3193,14 +3193,6 @@ html {
   .products-services-page .services-final-cta {
     padding: 1rem;
     border-radius: 0.85rem;
-  }
-
-  .products-services-page .services-collapsible-content {
-    display: none;
-  }
-
-  .products-services-page .services-collapsible-content.is-open {
-    display: block;
   }
 
   .products-services-page .services-final-cta-button {

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2904,6 +2904,7 @@ html {
   max-width: 820px;
   font-size: 1.04rem;
   line-height: 1.65;
+  margin-bottom: 20px !important;
 }
 
 .products-services-page .services-trust-chip {
@@ -2911,9 +2912,16 @@ html {
   border: 1px solid color-mix(in srgb, var(--accent-color) 35%, white);
   color: var(--text-cleanar-color);
   border-radius: 999px;
-  padding: 0.38rem 0.85rem;
+  padding: 6px 14px;
   font-size: 0.84rem;
   font-weight: 600;
+  margin-right: 8px;
+  margin-bottom: 10px;
+  border-radius: 20px;
+}
+
+.products-services-page .services-hero .services-trust-chip:last-child {
+  margin-right: 0;
 }
 
 .products-services-page .services-hero-cta-wrap .btn {
@@ -2976,6 +2984,21 @@ html {
   box-shadow: var(--cleanar-shadow-soft);
   border-radius: 1rem;
   padding: 1.3rem;
+}
+
+.products-services-page .services-revamp .row.g-3 {
+  --bs-gutter-y: 20px;
+  --bs-gutter-x: 16px;
+  row-gap: 20px !important;
+  column-gap: 16px !important;
+}
+
+.products-services-page .services-revamp .service-selector > section {
+  margin-bottom: 40px !important;
+}
+
+.products-services-page .services-revamp h2 {
+  margin-bottom: 16px !important;
 }
 
 .products-services-page .services-mobile-section-toggle {
@@ -3048,11 +3071,24 @@ html {
   background: color-mix(in srgb, var(--cleanar-surface-card) 96%, white);
   min-height: 100%;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  padding: 6px;
 }
 
 .products-services-page .service-revamp-card:hover {
   transform: translateY(-3px);
   box-shadow: var(--cleanar-shadow-hover);
+}
+
+.products-services-page .service-revamp-card .card-body {
+  padding: 18px 18px 16px;
+}
+
+.products-services-page .service-revamp-card h3 {
+  margin-bottom: 10px;
+}
+
+.products-services-page .service-revamp-card p {
+  margin-bottom: 10px;
 }
 
 .products-services-page .service-card-kicker {
@@ -3069,6 +3105,7 @@ html {
   font-size: 0.9rem;
   text-decoration: underline;
   text-underline-offset: 0.2rem;
+  margin-right: 12px;
 }
 
 .products-services-page .services-card-actions {
@@ -3077,6 +3114,10 @@ html {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.55rem;
+}
+
+.products-services-page .service-revamp-card .btn {
+  margin-top: 10px;
 }
 
 .products-services-page .service-package-card {
@@ -3126,6 +3167,12 @@ html {
   border-radius: 0.9rem;
   background: color-mix(in srgb, var(--cleanar-surface-card) 96%, white);
   padding: 1rem;
+}
+
+.products-services-page .services-how-compact .row.g-2,
+.products-services-page .services-how-compact .row.g-3 {
+  margin-top: 16px;
+  row-gap: 20px;
 }
 
 .products-services-page .services-process-number {
@@ -3285,6 +3332,10 @@ html {
 }
 
 @media (max-width: 575.98px) {
+  .products-services-page .services-revamp .service-selector > section {
+    margin-bottom: 28px !important;
+  }
+
   .products-services-page .services-revamp {
     padding-bottom: 3rem;
   }
@@ -3326,6 +3377,7 @@ html {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    margin-bottom: 8px;
   }
 
   .products-services-page .services-hero-cta-wrap {
@@ -3338,5 +3390,9 @@ html {
     padding-top: 0.55rem;
     padding-bottom: 0.55rem;
     font-size: 0.9rem;
+  }
+
+  .products-services-page .service-revamp-card .card-body {
+    padding: 16px;
   }
 }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2874,6 +2874,11 @@ html {
   padding-bottom: 4rem;
 }
 
+.products-services-page .services-revamp section[id],
+.products-services-page .services-revamp [id] {
+  scroll-margin-top: var(--services-scroll-offset, 120px);
+}
+
 .products-services-page .services-page-shell {
   max-width: 1180px;
   padding-left: 1rem;
@@ -2987,6 +2992,19 @@ html {
   align-items: center;
   justify-content: space-between;
   margin: 0.1rem 0 0.7rem;
+}
+
+.products-services-page .services-mobile-toggle-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  gap: 0.1rem;
+}
+
+.products-services-page .services-mobile-toggle-copy small {
+  font-size: 0.74rem;
+  opacity: 0.82;
 }
 
 .products-services-page .services-collapsible-content {
@@ -3177,7 +3195,14 @@ html {
     border-radius: 0.85rem;
   }
 
-  .products-services-page .services-hero-cta-wrap .btn,
+  .products-services-page .services-collapsible-content {
+    display: none;
+  }
+
+  .products-services-page .services-collapsible-content.is-open {
+    display: block;
+  }
+
   .products-services-page .services-final-cta-button {
     width: 100%;
   }
@@ -3188,62 +3213,6 @@ html {
 
   .products-services-page .services-back-to-top {
     font-size: 0.8rem;
-  }
-}
-
-@media (max-width: 575.98px) {
-  .products-services-page .services-revamp {
-    padding-bottom: 3rem;
-  }
-
-  .products-services-page .services-page-shell {
-    padding-left: 0.72rem;
-    padding-right: 0.72rem;
-  }
-
-  .products-services-page .services-hero {
-    padding: 0.95rem 0.9rem;
-  }
-
-  .products-services-page .services-hero h1 {
-    font-size: clamp(2rem, 9vw, 2.65rem);
-    line-height: 1.08;
-    margin-bottom: 0.7rem !important;
-  }
-
-  .products-services-page .services-hero-subtitle {
-    font-size: 0.93rem;
-    line-height: 1.5;
-    max-width: 100%;
-    margin-bottom: 0.75rem !important;
-  }
-
-  .products-services-page .services-trust-grid {
-    gap: 0.4rem !important;
-    margin-bottom: 0.75rem !important;
-    display: grid !important;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .products-services-page .services-trust-chip {
-    font-size: 0.75rem;
-    padding: 0.3rem 0.48rem;
-    text-align: center;
-    min-height: 38px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .products-services-page .services-hero-cta-wrap {
-    gap: 0.45rem !important;
-  }
-
-  .products-services-page .services-hero-cta-wrap .btn {
-    min-height: 42px;
-    padding-top: 0.55rem;
-    padding-bottom: 0.55rem;
-    font-size: 0.9rem;
   }
 
   .products-services-page .services-category-nav {
@@ -3260,14 +3229,6 @@ html {
   .products-services-page .services-section-panel {
     padding: 0.9rem;
     margin-bottom: 0.9rem !important;
-  }
-
-  .products-services-page .services-collapsible-content {
-    display: none;
-  }
-
-  .products-services-page .services-collapsible-content.is-open {
-    display: block;
   }
 
   .products-services-page .service-revamp-card .card-body,
@@ -3328,5 +3289,62 @@ html {
   .products-services-page .services-final-cta-support {
     font-size: 0.88rem;
     margin-bottom: 0.7rem !important;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .products-services-page .services-revamp {
+    padding-bottom: 3rem;
+  }
+
+  .products-services-page .services-page-shell {
+    padding-left: 0.72rem;
+    padding-right: 0.72rem;
+  }
+
+  .products-services-page .services-hero {
+    padding: 0.95rem 0.9rem;
+  }
+
+  .products-services-page .services-hero h1 {
+    font-size: clamp(2rem, 9vw, 2.65rem);
+    line-height: 1.08;
+    margin-bottom: 0.7rem !important;
+  }
+
+  .products-services-page .services-hero-subtitle {
+    font-size: 0.93rem;
+    line-height: 1.5;
+    max-width: 100%;
+    margin-bottom: 0.75rem !important;
+  }
+
+  .products-services-page .services-trust-grid {
+    gap: 0.4rem !important;
+    margin-bottom: 0.75rem !important;
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .products-services-page .services-trust-chip {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.48rem;
+    text-align: center;
+    min-height: 38px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .products-services-page .services-hero-cta-wrap {
+    gap: 0.45rem !important;
+  }
+
+  .products-services-page .services-hero-cta-wrap .btn {
+    width: 100%;
+    min-height: 42px;
+    padding-top: 0.55rem;
+    padding-bottom: 0.55rem;
+    font-size: 0.9rem;
   }
 }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -3037,6 +3037,7 @@ html {
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .products-services-page .services-back-to-top {
@@ -3050,6 +3051,8 @@ html {
   padding: 0.2rem 0.3rem;
   border-radius: 0.35rem;
   white-space: nowrap;
+  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 .products-services-page .services-back-to-top:hover,
@@ -3334,6 +3337,18 @@ html {
 }
 
 @media (max-width: 575.98px) {
+  .products-services-page .services-section-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .products-services-page .services-back-to-top {
+    align-self: flex-start;
+    margin-left: 0;
+    white-space: normal;
+  }
+
   .products-services-page .services-revamp .service-selector > section {
     margin-bottom: 28px !important;
   }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2965,6 +2965,31 @@ html {
   padding: 1.3rem;
 }
 
+.products-services-page .services-section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.products-services-page .services-back-to-top {
+  border: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-cleanar-color) 82%, white);
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.18rem;
+  padding: 0.2rem 0.3rem;
+  border-radius: 0.35rem;
+  white-space: nowrap;
+}
+
+.products-services-page .services-back-to-top:hover,
+.products-services-page .services-back-to-top:focus-visible {
+  background: color-mix(in srgb, var(--light-color) 50%, white);
+}
+
 .products-services-page .services-section-panel-premium {
   border-color: color-mix(in srgb, var(--accent-color) 45%, white);
   background: linear-gradient(145deg, color-mix(in srgb, var(--cleanar-surface-card) 97%, white), color-mix(in srgb, var(--light-blue-color) 35%, white));
@@ -2992,6 +3017,19 @@ html {
   letter-spacing: 0.06em;
   color: color-mix(in srgb, var(--text-cleanar-color) 75%, white);
   font-weight: 700;
+}
+
+.products-services-page .services-inline-link {
+  font-size: 0.9rem;
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.products-services-page .services-card-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.55rem;
 }
 
 .products-services-page .service-package-card {
@@ -3090,6 +3128,12 @@ html {
   .products-services-page .services-hero-cta-wrap .btn {
     min-width: 185px;
   }
+
+  .products-services-page .services-card-actions {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
 }
 
 @media (max-width: 767.98px) {
@@ -3107,5 +3151,13 @@ html {
   .products-services-page .services-hero-cta-wrap .btn,
   .products-services-page .services-final-cta-button {
     width: 100%;
+  }
+
+  .products-services-page .services-section-head {
+    align-items: center;
+  }
+
+  .products-services-page .services-back-to-top {
+    font-size: 0.8rem;
   }
 }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2878,6 +2878,7 @@ html {
   max-width: 1180px;
   padding-left: 1rem;
   padding-right: 1rem;
+  overflow-x: clip;
 }
 
 .products-services-page .services-revamp .service-selector {
@@ -2930,6 +2931,12 @@ html {
   overflow-x: auto;
   padding: 0.25rem 0.1rem 0.4rem;
   scrollbar-width: thin;
+  scroll-snap-type: x proximity;
+  -webkit-overflow-scrolling: touch;
+}
+
+.products-services-page .services-category-nav::-webkit-scrollbar {
+  display: none;
 }
 
 .products-services-page .services-category-chip {
@@ -2942,6 +2949,7 @@ html {
   font-size: 0.86rem;
   white-space: nowrap;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  scroll-snap-align: start;
 }
 
 .products-services-page .services-category-chip:hover,
@@ -2963,6 +2971,26 @@ html {
   box-shadow: var(--cleanar-shadow-soft);
   border-radius: 1rem;
   padding: 1.3rem;
+}
+
+.products-services-page .services-mobile-toggle {
+  width: 100%;
+  border: 1px solid var(--cleanar-surface-border);
+  background: color-mix(in srgb, var(--light-color) 45%, white);
+  color: var(--text-cleanar-color);
+  border-radius: 0.75rem;
+  min-height: 44px;
+  padding: 0.55rem 0.7rem;
+  font-size: 0.86rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0.1rem 0 0.7rem;
+}
+
+.products-services-page .services-collapsible-content {
+  display: block;
 }
 
 .products-services-page .services-section-head {
@@ -3027,8 +3055,9 @@ html {
 
 .products-services-page .services-card-actions {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.55rem;
 }
 
@@ -3159,5 +3188,145 @@ html {
 
   .products-services-page .services-back-to-top {
     font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .products-services-page .services-revamp {
+    padding-bottom: 3rem;
+  }
+
+  .products-services-page .services-page-shell {
+    padding-left: 0.72rem;
+    padding-right: 0.72rem;
+  }
+
+  .products-services-page .services-hero {
+    padding: 0.95rem 0.9rem;
+  }
+
+  .products-services-page .services-hero h1 {
+    font-size: clamp(2rem, 9vw, 2.65rem);
+    line-height: 1.08;
+    margin-bottom: 0.7rem !important;
+  }
+
+  .products-services-page .services-hero-subtitle {
+    font-size: 0.93rem;
+    line-height: 1.5;
+    max-width: 100%;
+    margin-bottom: 0.75rem !important;
+  }
+
+  .products-services-page .services-trust-grid {
+    gap: 0.4rem !important;
+    margin-bottom: 0.75rem !important;
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .products-services-page .services-trust-chip {
+    font-size: 0.75rem;
+    padding: 0.3rem 0.48rem;
+    text-align: center;
+    min-height: 38px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .products-services-page .services-hero-cta-wrap {
+    gap: 0.45rem !important;
+  }
+
+  .products-services-page .services-hero-cta-wrap .btn {
+    min-height: 42px;
+    padding-top: 0.55rem;
+    padding-bottom: 0.55rem;
+    font-size: 0.9rem;
+  }
+
+  .products-services-page .services-category-nav {
+    gap: 0.4rem;
+    padding: 0.2rem 0.2rem 0.35rem;
+  }
+
+  .products-services-page .services-category-chip {
+    padding: 0.35rem 0.72rem;
+    font-size: 0.8rem;
+    min-height: 40px;
+  }
+
+  .products-services-page .services-section-panel {
+    padding: 0.9rem;
+    margin-bottom: 0.9rem !important;
+  }
+
+  .products-services-page .services-collapsible-content {
+    display: none;
+  }
+
+  .products-services-page .services-collapsible-content.is-open {
+    display: block;
+  }
+
+  .products-services-page .service-revamp-card .card-body,
+  .products-services-page .premium-service-card .card-body {
+    padding: 0.8rem;
+  }
+
+  .products-services-page .services-card-description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .products-services-page .services-card-actions {
+    justify-content: space-between;
+  }
+
+  .products-services-page .services-card-actions .btn {
+    min-height: 40px;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.82rem;
+  }
+
+  .products-services-page .services-inline-link {
+    font-size: 0.82rem;
+  }
+
+  .products-services-page .services-item-pill {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.56rem;
+  }
+
+  .products-services-page .services-process-card {
+    padding: 0.75rem;
+  }
+
+  .products-services-page .services-process-number {
+    width: 1.7rem;
+    height: 1.7rem;
+    font-size: 0.82rem;
+  }
+
+  .products-services-page .services-how-compact .h6 {
+    font-size: 0.88rem;
+  }
+
+  .products-services-page .services-final-cta {
+    padding: 0.95rem;
+    margin-bottom: 2.7rem;
+  }
+
+  .products-services-page .services-final-cta .title {
+    margin-bottom: 0.55rem !important;
+    font-size: 1.4rem;
+  }
+
+  .products-services-page .services-final-cta-support {
+    font-size: 0.88rem;
+    margin-bottom: 0.7rem !important;
   }
 }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2871,78 +2871,205 @@ html {
 .products-services-page .services-revamp {
   background-size: cover;
   background-position: center;
+  padding-bottom: 4rem;
+}
+
+.products-services-page .services-page-shell {
+  max-width: 1180px;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.products-services-page .services-revamp .service-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.products-services-page .services-hero {
+  background: color-mix(in srgb, var(--cleanar-surface-card) 94%, white);
+  border: 1px solid var(--cleanar-surface-border);
+  box-shadow: var(--cleanar-shadow-soft);
+  border-radius: 1rem;
+  padding: 1.5rem 1.25rem;
 }
 
 .products-services-page .services-hero-subtitle {
-  max-width: 880px;
-  font-size: 1.05rem;
+  max-width: 820px;
+  font-size: 1.04rem;
+  line-height: 1.65;
 }
 
 .products-services-page .services-trust-chip {
-  background: #ffffff;
-  border: 1px solid rgba(30, 58, 138, 0.12);
-  color: #0f766e;
+  background: color-mix(in srgb, var(--light-color) 78%, white);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 35%, white);
+  color: var(--text-cleanar-color);
   border-radius: 999px;
-  padding: 0.35rem 0.8rem;
+  padding: 0.38rem 0.85rem;
   font-size: 0.84rem;
   font-weight: 600;
+}
+
+.products-services-page .services-hero-cta-wrap .btn {
+  min-height: 46px;
+}
+
+.products-services-page .services-hero-primary-cta {
+  box-shadow: var(--cleanar-shadow-soft);
+}
+
+.products-services-page .services-hero-secondary-cta {
+  border-color: color-mix(in srgb, var(--accent-color) 45%, white);
+  color: var(--text-cleanar-color);
+  background: color-mix(in srgb, var(--cleanar-surface-card) 88%, white);
 }
 
 .products-services-page .services-category-nav {
   display: flex;
   gap: 0.5rem;
-  flex-wrap: wrap;
+  overflow-x: auto;
+  padding: 0.25rem 0.1rem 0.4rem;
+  scrollbar-width: thin;
 }
 
 .products-services-page .services-category-chip {
-  border: 1px solid rgba(15, 118, 110, 0.35);
-  background: #fff;
-  color: #0f766e;
+  border: 1px solid color-mix(in srgb, var(--accent-color) 40%, white);
+  background: color-mix(in srgb, var(--cleanar-surface-card) 90%, white);
+  color: var(--text-cleanar-color);
   border-radius: 999px;
-  padding: 0.35rem 0.85rem;
-  font-weight: 600;
+  padding: 0.42rem 0.95rem;
+  font-weight: 700;
   font-size: 0.86rem;
+  white-space: nowrap;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .products-services-page .services-category-chip:hover,
 .products-services-page .services-category-chip:focus-visible {
-  background: #e6fffa;
+  background: color-mix(in srgb, var(--light-color) 60%, white);
+  box-shadow: var(--cleanar-shadow-soft);
+  transform: translateY(-1px);
+}
+
+.products-services-page .services-category-chip.is-active {
+  background: linear-gradient(135deg, color-mix(in srgb, var(--light-blue-color) 65%, white), color-mix(in srgb, var(--light-color) 78%, white));
+  border-color: color-mix(in srgb, var(--primary-color) 45%, white);
+  color: var(--text-cleanar-color);
+}
+
+.products-services-page .services-section-panel {
+  background: color-mix(in srgb, var(--cleanar-surface-card) 95%, white);
+  border: 1px solid var(--cleanar-surface-border);
+  box-shadow: var(--cleanar-shadow-soft);
+  border-radius: 1rem;
+  padding: 1.3rem;
+}
+
+.products-services-page .services-section-panel-premium {
+  border-color: color-mix(in srgb, var(--accent-color) 45%, white);
+  background: linear-gradient(145deg, color-mix(in srgb, var(--cleanar-surface-card) 97%, white), color-mix(in srgb, var(--light-blue-color) 35%, white));
 }
 
 .products-services-page .service-revamp-card {
-  border: 1px solid rgba(15, 118, 110, 0.12);
+  border: 1px solid var(--cleanar-surface-border);
+  box-shadow: var(--cleanar-shadow-soft);
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--cleanar-surface-card) 96%, white);
+  min-height: 100%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.products-services-page .service-revamp-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--cleanar-shadow-hover);
+}
+
+.products-services-page .service-card-kicker {
+  display: inline-block;
+  margin-bottom: 0.65rem;
+  font-size: 0.73rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: color-mix(in srgb, var(--text-cleanar-color) 75%, white);
+  font-weight: 700;
+}
+
+.products-services-page .service-package-card {
+  background: linear-gradient(145deg, color-mix(in srgb, var(--cleanar-surface-card) 98%, white), color-mix(in srgb, var(--light-color) 35%, white));
+}
+
+.products-services-page .service-split-card .services-item-pill {
+  background: color-mix(in srgb, var(--light-blue-color) 42%, white);
+}
+
+.products-services-page .services-subtle-note {
+  margin-top: -0.25rem;
+  margin-bottom: 0.9rem;
+  color: var(--text-cleanar-color);
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.products-services-page .services-pills-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.products-services-page .services-item-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent-color) 28%, white);
+  background: color-mix(in srgb, var(--light-color) 62%, white);
+  color: var(--text-cleanar-color);
+  padding: 0.3rem 0.7rem;
+  font-size: 0.82rem;
+  line-height: 1.25;
 }
 
 .products-services-page .premium-service-card {
-  border: 1px solid rgba(30, 64, 175, 0.18);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(239, 246, 255, 0.88));
+  border: 1px solid color-mix(in srgb, var(--primary-color) 35%, white);
+  background: linear-gradient(145deg, color-mix(in srgb, var(--cleanar-surface-card) 98%, white), color-mix(in srgb, var(--light-blue-color) 40%, white));
+  box-shadow: var(--cleanar-shadow-soft);
+  border-radius: 0.95rem;
 }
 
-.products-services-page .services-compact-list {
-  padding-left: 1.1rem;
-  margin-bottom: 0;
+.products-services-page .services-process-card {
+  border: 1px solid var(--cleanar-surface-border);
+  box-shadow: var(--cleanar-shadow-soft);
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--cleanar-surface-card) 96%, white);
+  padding: 1rem;
 }
 
-.products-services-page .services-compact-list li {
-  margin-bottom: 0.35rem;
-}
-
-.products-services-page .services-steps-list {
-  margin: 0;
-  padding-left: 1.2rem;
-}
-
-.products-services-page .services-steps-list li {
-  margin-bottom: 0.4rem;
-  font-weight: 600;
-  color: #0f172a;
+.products-services-page .services-process-number {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  background: linear-gradient(140deg, color-mix(in srgb, var(--secondary-color) 65%, white), color-mix(in srgb, var(--light-blue-color) 48%, white));
+  color: var(--text-cleanar-color);
 }
 
 .products-services-page .services-final-cta {
-  border: 1px solid rgba(15, 118, 110, 0.18);
-  border-radius: 16px;
-  padding: 1.25rem;
-  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 42%, white);
+  border-radius: 1rem;
+  padding: 1.45rem;
+  background: linear-gradient(140deg, color-mix(in srgb, var(--cleanar-surface-card) 98%, white), color-mix(in srgb, var(--light-color) 45%, white));
+  box-shadow: var(--cleanar-shadow-soft);
+  margin-bottom: 2.25rem;
+}
+
+.products-services-page .services-final-cta-support {
+  max-width: 780px;
+}
+
+.products-services-page .services-final-cta-button {
+  min-width: 210px;
 }
 
 @media (min-width: 768px) {
@@ -2950,9 +3077,35 @@ html {
     position: sticky;
     top: 88px;
     z-index: 4;
-    padding: 0.6rem;
-    background: rgba(255, 255, 255, 0.92);
+    padding: 0.55rem;
+    background: color-mix(in srgb, var(--cleanar-surface-card) 94%, white);
     border-radius: 12px;
-    backdrop-filter: blur(6px);
+    box-shadow: var(--cleanar-shadow-soft);
+  }
+
+  .products-services-page .services-hero {
+    padding: 1.9rem;
+  }
+
+  .products-services-page .services-hero-cta-wrap .btn {
+    min-width: 185px;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .products-services-page .services-revamp .service-selector {
+    gap: 1rem;
+  }
+
+  .products-services-page .services-section-panel,
+  .products-services-page .services-hero,
+  .products-services-page .services-final-cta {
+    padding: 1rem;
+    border-radius: 0.85rem;
+  }
+
+  .products-services-page .services-hero-cta-wrap .btn,
+  .products-services-page .services-final-cta-button {
+    width: 100%;
   }
 }

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2989,8 +2989,6 @@ html {
 .products-services-page .services-revamp .row.g-3 {
   --bs-gutter-y: 20px;
   --bs-gutter-x: 16px;
-  row-gap: 20px !important;
-  column-gap: 16px !important;
 }
 
 .products-services-page .services-revamp .service-selector > section {
@@ -3069,6 +3067,8 @@ html {
   box-shadow: var(--cleanar-shadow-soft);
   border-radius: 0.9rem;
   background: color-mix(in srgb, var(--cleanar-surface-card) 96%, white);
+  width: 100%;
+  max-width: none;
   min-height: 100%;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   padding: 6px;
@@ -3159,6 +3159,8 @@ html {
   background: linear-gradient(145deg, color-mix(in srgb, var(--cleanar-surface-card) 98%, white), color-mix(in srgb, var(--light-blue-color) 40%, white));
   box-shadow: var(--cleanar-shadow-soft);
   border-radius: 0.95rem;
+  width: 100%;
+  max-width: none;
 }
 
 .products-services-page .services-process-card {

--- a/client/src/assets/css/our-palette.css
+++ b/client/src/assets/css/our-palette.css
@@ -2866,3 +2866,93 @@ html {
   padding-bottom: 0.85rem;
   border-radius: 0.9rem;
 }
+
+/* Services page revamp */
+.products-services-page .services-revamp {
+  background-size: cover;
+  background-position: center;
+}
+
+.products-services-page .services-hero-subtitle {
+  max-width: 880px;
+  font-size: 1.05rem;
+}
+
+.products-services-page .services-trust-chip {
+  background: #ffffff;
+  border: 1px solid rgba(30, 58, 138, 0.12);
+  color: #0f766e;
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.products-services-page .services-category-nav {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.products-services-page .services-category-chip {
+  border: 1px solid rgba(15, 118, 110, 0.35);
+  background: #fff;
+  color: #0f766e;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  font-size: 0.86rem;
+}
+
+.products-services-page .services-category-chip:hover,
+.products-services-page .services-category-chip:focus-visible {
+  background: #e6fffa;
+}
+
+.products-services-page .service-revamp-card {
+  border: 1px solid rgba(15, 118, 110, 0.12);
+}
+
+.products-services-page .premium-service-card {
+  border: 1px solid rgba(30, 64, 175, 0.18);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(239, 246, 255, 0.88));
+}
+
+.products-services-page .services-compact-list {
+  padding-left: 1.1rem;
+  margin-bottom: 0;
+}
+
+.products-services-page .services-compact-list li {
+  margin-bottom: 0.35rem;
+}
+
+.products-services-page .services-steps-list {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.products-services-page .services-steps-list li {
+  margin-bottom: 0.4rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.products-services-page .services-final-cta {
+  border: 1px solid rgba(15, 118, 110, 0.18);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+@media (min-width: 768px) {
+  .products-services-page .services-category-nav {
+    position: sticky;
+    top: 88px;
+    z-index: 4;
+    padding: 0.6rem;
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 12px;
+    backdrop-filter: blur(6px);
+  }
+}

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Row, Col, Card, Button } from 'react-bootstrap';
+import { Row, Col, Card, Button, Container } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
 import pageBg from "/src/assets/img/bg1.png";
@@ -31,6 +31,14 @@ const SPECIALTY_QUERY = {
 
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
+  const [activeCategory, setActiveCategory] = useState('core');
+
+  const howItWorksSteps = t('products_and_services.revamp.howItWorks.steps', { returnObjects: true });
+  const howItWorksDescriptions = t('products_and_services.revamp.howItWorks.stepDescriptions', { returnObjects: true });
+  const howItWorksItems = useMemo(
+    () => howItWorksSteps.map((title, index) => ({ title, description: howItWorksDescriptions[index] || '' })),
+    [howItWorksDescriptions, howItWorksSteps]
+  );
 
   const jumpToSection = (targetId) => {
     const section = document.getElementById(targetId);
@@ -59,6 +67,7 @@ const ProductsAndServices = () => {
     <section className="section-background services-revamp" style={{ backgroundImage: `url(${pageBg})` }}>
       <VisitorCounter page={'products-and-services'} />
 
+      <Container className="services-page-shell">
       <section className="service-selector pb-5">
         <div className="services-hero pt-5 mb-4">
           <h1 className="title primary-color text-bold mb-3">
@@ -74,11 +83,11 @@ const ProductsAndServices = () => {
             ))}
           </div>
 
-          <div className="d-flex flex-wrap gap-2">
-            <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color">
+          <div className="d-flex flex-wrap gap-2 services-hero-cta-wrap">
+            <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-hero-primary-cta">
               {t('products_and_services.revamp.hero.primaryCta')}
             </Button>
-            <Button variant="outline-secondary" className="btn-round" onClick={() => jumpToSection('services')}>
+            <Button variant="outline-secondary" className="btn-round services-hero-secondary-cta" onClick={() => jumpToSection('services')}>
               {t('products_and_services.revamp.hero.secondaryCta')}
             </Button>
           </div>
@@ -89,23 +98,27 @@ const ProductsAndServices = () => {
             <button
               key={item.key}
               type="button"
-              className="services-category-chip"
-              onClick={() => jumpToSection(item.target)}
+              className={`services-category-chip ${activeCategory === item.key ? 'is-active' : ''}`}
+              onClick={() => {
+                setActiveCategory(item.key);
+                jumpToSection(item.target);
+              }}
             >
               {t(`products_and_services.revamp.categoryNav.${item.key}`)}
             </button>
           ))}
         </nav>
 
-        <section id="services" className="mb-5">
+        <section id="services" className="mb-5 services-section-panel">
           <h2 id="core-services" className="title secondary-color text-bold mb-3">
             {t('products_and_services.revamp.core.title')}
           </h2>
           <Row className="g-3">
             {Object.entries(t('products_and_services.revamp.core.items', { returnObjects: true })).map(([key, service]) => (
               <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
-                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                <Card className="h-100 service-revamp-card">
                   <Card.Body className="d-flex flex-column">
+                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.core')}</span>
                     <Card.Title as="h3" className="h5 text-cleanar-color text-bold mb-2">{service.name}</Card.Title>
                     <Card.Text className="mb-2 text-muted">{service.description}</Card.Text>
                     <p className="small mb-3 text-cleanar-color"><strong>{t('products_and_services.revamp.core.bestForLabel')}</strong> {service.bestFor}</p>
@@ -119,14 +132,16 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="cleaning-packages" className="mb-5">
+        <section id="cleaning-packages" className="mb-5 services-section-panel">
           <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
           <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
+          <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
           <Row className="g-3">
             {t('products_and_services.revamp.packages.items', { returnObjects: true }).map((pkg) => (
               <Col xs={12} md={4} key={pkg.name}>
-                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                <Card className="h-100 service-revamp-card service-package-card">
                   <Card.Body>
+                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.packages')}</span>
                     <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{pkg.name}</Card.Title>
                     <p className="text-muted mb-2">{pkg.pricing}</p>
                     <p className="small mb-0">{pkg.note}</p>
@@ -137,18 +152,18 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="add-ons" className="mb-5">
+        <section id="add-ons" className="mb-5 services-section-panel">
           <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
           <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
           <Row className="g-3">
             {Object.values(t('products_and_services.revamp.addons.groups', { returnObjects: true })).map((group) => (
               <Col xs={12} md={6} key={group.title}>
-                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                <Card className="h-100 service-revamp-card">
                   <Card.Body>
                     <Card.Title as="h3" className="h6 text-cleanar-color text-bold">{group.title}</Card.Title>
-                    <ul className="mb-0 services-compact-list">
-                      {group.items.map((item) => <li key={item}>{item}</li>)}
-                    </ul>
+                    <div className="services-pills-list">
+                      {group.items.map((item) => <span key={item} className="services-item-pill">{item}</span>)}
+                    </div>
                   </Card.Body>
                 </Card>
               </Col>
@@ -156,18 +171,19 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="carpet-upholstery" className="mb-5">
+        <section id="carpet-upholstery" className="mb-5 services-section-panel">
           <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
           <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
           <Row className="g-3">
             {Object.values(t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true })).map((column) => (
               <Col xs={12} md={6} key={column.title}>
-                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                <Card className="h-100 service-revamp-card service-split-card">
                   <Card.Body>
+                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.carpetUpholstery')}</span>
                     <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{column.title}</Card.Title>
-                    <ul className="mb-0 services-compact-list">
-                      {column.items.map((item) => <li key={item}>{item}</li>)}
-                    </ul>
+                    <div className="services-pills-list">
+                      {column.items.map((item) => <span key={item} className="services-item-pill">{item}</span>)}
+                    </div>
                   </Card.Body>
                 </Card>
               </Col>
@@ -175,13 +191,14 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="specialty-services" className="mb-5">
+        <section id="specialty-services" className="mb-5 services-section-panel services-section-panel-premium">
           <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
           <Row className="g-3">
             {Object.entries(t('products_and_services.revamp.specialty.items', { returnObjects: true })).map(([key, item]) => (
               <Col xs={12} md={4} key={key}>
-                <Card className="h-100 shadow premium-service-card">
+                <Card className="h-100 premium-service-card">
                   <Card.Body className="d-flex flex-column">
+                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>
                     <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
                     <Card.Text className="text-muted mb-3">{item.description}</Card.Text>
                     <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color mt-auto">
@@ -194,23 +211,32 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section className="mb-5">
+        <section className="mb-5 services-section-panel">
           <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
-          <ol className="services-steps-list">
-            {t('products_and_services.revamp.howItWorks.steps', { returnObjects: true }).map((step) => (
-              <li key={step}>{step}</li>
+          <Row className="g-3">
+            {howItWorksItems.map((step, index) => (
+              <Col xs={12} md={6} lg={3} key={step.title}>
+                <article className="services-process-card h-100">
+                  <span className="services-process-number">{index + 1}</span>
+                  <h3 className="h6 text-cleanar-color text-bold mt-3 mb-2">{step.title}</h3>
+                  <p className="mb-0 text-muted small">{step.description}</p>
+                </article>
+              </Col>
             ))}
-          </ol>
+          </Row>
         </section>
 
         <section className="services-final-cta">
           <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
           <p className="mb-3 text-cleanar-color">{t('products_and_services.revamp.finalCta.description')}</p>
-          <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color">
+          <p className="services-final-cta-support text-muted mb-3">{t('products_and_services.revamp.finalCta.supportText')}</p>
+          <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-final-cta-button">
             {t('products_and_services.revamp.finalCta.button')}
           </Button>
         </section>
+
       </section>
+      </Container>
     </section>
   );
 };

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -29,6 +29,19 @@ const SPECIALTY_QUERY = {
   monthlyBuilding: 'Commercial+Cleaning'
 };
 
+const SERVICE_ROUTE_BY_KEY = {
+  residentialRegular: '/services/residential-cleaning',
+  residentialDeep: '/services/deep-cleaning',
+  moveInOut: '/services/move-in-move-out-cleaning',
+  commercialRegular: '/services/commercial-cleaning',
+  commercialDeep: '/services/commercial-deep-cleaning',
+  carpetCleaning: '/services/carpet-cleaning',
+  upholsteryCleaning: '/services/upholstery-cleaning',
+  postConstruction: '/services/post-construction-cleaning',
+  fullUnitCleanOut: '/services/full-unit-clean-out',
+  monthlyBuilding: '/services/monthly-building-amenities-cleaning'
+};
+
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
   const [activeCategory, setActiveCategory] = useState('core');
@@ -51,6 +64,8 @@ const ProductsAndServices = () => {
     ? `/?service=${serviceQuery}&scrollToQuote=true`
     : '/?scrollToQuote=true');
 
+  const getDisplayListItem = (item) => (item.includes('–') ? item.split('–')[1].trim() : item);
+
   useEffect(() => {
     document.body.classList.add('products-services-page');
     document.body.classList.add('sidebar-collapse');
@@ -68,8 +83,8 @@ const ProductsAndServices = () => {
       <VisitorCounter page={'products-and-services'} />
 
       <Container className="services-page-shell">
-      <section className="service-selector pb-5">
-        <div className="services-hero pt-5 mb-4">
+        <section className="service-selector pb-5">
+          <div id="services-top" className="services-hero pt-5 mb-4">
           <h1 className="title primary-color text-bold mb-3">
             {t('products_and_services.revamp.hero.title')}
           </h1>
@@ -93,7 +108,7 @@ const ProductsAndServices = () => {
           </div>
         </div>
 
-        <nav className="services-category-nav mb-4" aria-label={t('products_and_services.revamp.categoryNav.ariaLabel')}>
+          <nav className="services-category-nav mb-4" aria-label={t('products_and_services.revamp.categoryNav.ariaLabel')}>
           {categoryAnchors.map((item) => (
             <button
               key={item.key}
@@ -107,12 +122,17 @@ const ProductsAndServices = () => {
               {t(`products_and_services.revamp.categoryNav.${item.key}`)}
             </button>
           ))}
-        </nav>
+          </nav>
 
-        <section id="services" className="mb-5 services-section-panel">
-          <h2 id="core-services" className="title secondary-color text-bold mb-3">
-            {t('products_and_services.revamp.core.title')}
-          </h2>
+          <section id="services" className="mb-5 services-section-panel">
+            <div className="services-section-head">
+              <h2 id="core-services" className="title secondary-color text-bold mb-3">
+                {t('products_and_services.revamp.core.title')}
+              </h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <Row className="g-3">
             {Object.entries(t('products_and_services.revamp.core.items', { returnObjects: true })).map(([key, service]) => (
               <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
@@ -122,9 +142,16 @@ const ProductsAndServices = () => {
                     <Card.Title as="h3" className="h5 text-cleanar-color text-bold mb-2">{service.name}</Card.Title>
                     <Card.Text className="mb-2 text-muted">{service.description}</Card.Text>
                     <p className="small mb-3 text-cleanar-color"><strong>{t('products_and_services.revamp.core.bestForLabel')}</strong> {service.bestFor}</p>
-                    <Button as={Link} to={quoteLink(CORE_SERVICE_QUERY[key])} className="btn-round secondary-bg-color mt-auto">
-                      {t('products_and_services.revamp.core.cta')}
-                    </Button>
+                    <div className="services-card-actions mt-auto">
+                      {SERVICE_ROUTE_BY_KEY[key] ? (
+                        <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
+                          {t('products_and_services.revamp.learnMore')}
+                        </Link>
+                      ) : null}
+                      <Button as={Link} to={quoteLink(CORE_SERVICE_QUERY[key])} className="btn-round secondary-bg-color">
+                        {t('products_and_services.revamp.core.cta')}
+                      </Button>
+                    </div>
                   </Card.Body>
                 </Card>
               </Col>
@@ -132,8 +159,13 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="cleaning-packages" className="mb-5 services-section-panel">
-          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
+          <section id="cleaning-packages" className="mb-5 services-section-panel">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
           <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
           <Row className="g-3">
@@ -152,8 +184,13 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="add-ons" className="mb-5 services-section-panel">
-          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
+          <section id="add-ons" className="mb-5 services-section-panel">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
           <Row className="g-3">
             {Object.values(t('products_and_services.revamp.addons.groups', { returnObjects: true })).map((group) => (
@@ -171,38 +208,31 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section id="carpet-upholstery" className="mb-5 services-section-panel">
-          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
+          <section id="carpet-upholstery" className="mb-5 services-section-panel">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
           <Row className="g-3">
-            {Object.values(t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true })).map((column) => (
+            {Object.entries(t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true })).map(([key, column]) => (
               <Col xs={12} md={6} key={column.title}>
                 <Card className="h-100 service-revamp-card service-split-card">
                   <Card.Body>
                     <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.carpetUpholstery')}</span>
                     <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{column.title}</Card.Title>
+                    {SERVICE_ROUTE_BY_KEY[`${key}Cleaning`] ? (
+                      <Link to={SERVICE_ROUTE_BY_KEY[`${key}Cleaning`]} className="services-inline-link text-cleanar-color text-bold">
+                        {t('products_and_services.revamp.learnMore')}
+                      </Link>
+                    ) : null}
                     <div className="services-pills-list">
-                      {column.items.map((item) => <span key={item} className="services-item-pill">{item}</span>)}
+                      {column.items.map((item) => <span key={item} className="services-item-pill">{getDisplayListItem(item)}</span>)}
                     </div>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
-
-        <section id="specialty-services" className="mb-5 services-section-panel services-section-panel-premium">
-          <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
-          <Row className="g-3">
-            {Object.entries(t('products_and_services.revamp.specialty.items', { returnObjects: true })).map(([key, item]) => (
-              <Col xs={12} md={4} key={key}>
-                <Card className="h-100 premium-service-card">
-                  <Card.Body className="d-flex flex-column">
-                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>
-                    <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
-                    <Card.Text className="text-muted mb-3">{item.description}</Card.Text>
-                    <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color mt-auto">
-                      {t('products_and_services.revamp.specialty.cta')}
+                    <Button as={Link} to={quoteLink(key === 'carpet' ? CORE_SERVICE_QUERY.carpetCleaning : CORE_SERVICE_QUERY.upholsteryCleaning)} className="btn-round secondary-bg-color mt-3">
+                      {t('products_and_services.revamp.core.cta')}
                     </Button>
                   </Card.Body>
                 </Card>
@@ -211,8 +241,45 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section className="mb-5 services-section-panel">
-          <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
+          <section id="specialty-services" className="mb-5 services-section-panel services-section-panel-premium">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
+          <Row className="g-3">
+            {Object.entries(t('products_and_services.revamp.specialty.items', { returnObjects: true })).map(([key, item]) => (
+              <Col xs={12} md={4} key={key}>
+                <Card className="h-100 premium-service-card">
+                  <Card.Body className="d-flex flex-column">
+                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>
+                    <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
+                    <Card.Text className="text-muted mb-3">{item.description}</Card.Text>
+                    <div className="services-card-actions mt-auto">
+                      {SERVICE_ROUTE_BY_KEY[key] ? (
+                        <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
+                          {t('products_and_services.revamp.learnMore')}
+                        </Link>
+                      ) : null}
+                      <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color">
+                        {t('products_and_services.revamp.specialty.cta')}
+                      </Button>
+                    </div>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+          <section className="mb-5 services-section-panel">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <Row className="g-3">
             {howItWorksItems.map((step, index) => (
               <Col xs={12} md={6} lg={3} key={step.title}>
@@ -226,16 +293,21 @@ const ProductsAndServices = () => {
           </Row>
         </section>
 
-        <section className="services-final-cta">
-          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
+          <section className="services-final-cta">
+            <div className="services-section-head">
+              <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
+            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              {t('products_and_services.revamp.backToTop')}
+            </button>
+            </div>
           <p className="mb-3 text-cleanar-color">{t('products_and_services.revamp.finalCta.description')}</p>
           <p className="services-final-cta-support text-muted mb-3">{t('products_and_services.revamp.finalCta.supportText')}</p>
           <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-final-cta-button">
             {t('products_and_services.revamp.finalCta.button')}
           </Button>
-        </section>
+          </section>
 
-      </section>
+        </section>
       </Container>
     </section>
   );

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -1,262 +1,215 @@
 import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Row, Col, Card, ListGroup, Button } from 'react-bootstrap';
+import { Row, Col, Card, Button } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
-
-import carpetAvif from "/src/assets/img/optimized/carpet-cleaning.avif";
-import carpetWebp from "/src/assets/img/optimized/carpet-cleaning.webp";
-import carpetJpg from "/src/assets/img/carpet-cleaning.jpg";
-
-import residentialAvif from "/src/assets/img/optimized/residential-cleaning.avif";
-import residentialWebp from "/src/assets/img/optimized/residential-cleaning.webp";
-import residentialJpg from "/src/assets/img/residential-cleaning.jpg";
-
-import commercialAvif from "/src/assets/img/optimized/commercial-cleaning.avif";
-import commercialWebp from "/src/assets/img/optimized/commercial-cleaning.webp";
-import commercialJpg from "/src/assets/img/commercial-cleaning.jpg";
-
-import pressureAvif from "/src/assets/img/optimized/pressure-cleaning.avif";
-import pressureWebp from "/src/assets/img/optimized/pressure-cleaning.webp";
-import pressureJpg from "/src/assets/img/pressure-cleaning.jpg";
-
-import windowAvif from "/src/assets/img/optimized/window-cleaning.avif";
-import windowWebp from "/src/assets/img/optimized/window-cleaning.webp";
-import windowJpg from "/src/assets/img/window-cleaning.jpg";
-
 import pageBg from "/src/assets/img/bg1.png";
 
-const TORONTO_SERVICE_ROUTE_BY_SLUG = {
-  "residential-cleaning": "/residential-cleaning-toronto",
-  "commercial-cleaning": "/commercial-cleaning-toronto",
-  "deep-cleaning": "/deep-cleaning-toronto",
-  "move-in-move-out-cleaning": "/move-in-move-out-cleaning-toronto",
-  "carpet-upholstery-cleaning": "/carpet-upholstery-cleaning-toronto",
+const categoryAnchors = [
+  { key: 'core', target: 'core-services' },
+  { key: 'packages', target: 'cleaning-packages' },
+  { key: 'addons', target: 'add-ons' },
+  { key: 'carpetUpholstery', target: 'carpet-upholstery' },
+  { key: 'specialty', target: 'specialty-services' }
+];
+
+const CORE_SERVICE_QUERY = {
+  residentialRegular: 'Residential+Cleaning',
+  residentialDeep: 'Deep+Cleaning',
+  moveInOut: 'Move+In+Move+Out+Cleaning',
+  commercialRegular: 'Commercial+Cleaning',
+  commercialDeep: 'Commercial+Cleaning',
+  carpetCleaning: 'Carpet+And+Upholstery',
+  upholsteryCleaning: 'Carpet+And+Upholstery'
 };
 
-const ServiceCard = ({
-  title,
-  avif,
-  webp,
-  fallback,
-  imgAlt,
-  width,
-  height,
-  description,
-  quoteLink,
-  quoteButtonText,
-  serviceSlug
-}) => {
-    const servicePageLink = serviceSlug ? TORONTO_SERVICE_ROUTE_BY_SLUG[serviceSlug] : null;
-  return (
-    <Card className="h-90 shadow-sm bg-transparent">
-      <picture>
-        <source srcSet={avif} type="image/avif" />
-        <source srcSet={webp} type="image/webp" />
-        <img
-          src={fallback}
-          alt={imgAlt}
-          width={width}
-          height={height}
-          loading="lazy"
-          decoding="async"
-          className="service-card-img card-img-top"
-          style={{ width: "100%", height: "auto" }}
-          sizes="(max-width: 767px) 92vw, (max-width: 1200px) 30vw, 360px"
-        />
-      </picture>
-
-      <Card.Body className="d-flex flex-column">
-        <Card.Title as="h3" className="text-bold text-cleanar-color">
-          {title}
-        </Card.Title>
-
-        <ListGroup className="flex-grow-1 mb-3">
-          {Array.isArray(description) ? (
-            description.map((item, index) => (
-              <ListGroup.Item key={index} className="px-0 py-1 border-0 bg-transparent">
-                {item}
-              </ListGroup.Item>
-            ))
-          ) : (
-            <ListGroup.Item className="px-0 py-1 border-0 bg-transparent">
-              {description}
-            </ListGroup.Item>
-          )}
-        </ListGroup>
-
-        <div className="d-flex flex-column gap-2 mt-auto">
-          {servicePageLink ? (
-            <Button as={Link} to={servicePageLink} variant="outline-secondary" className="btn-round">
-              Learn More
-            </Button>
-          ) : null}
-          <Button
-            href={quoteLink}
-            data-track={`clicked_add_to_quote_${title.replace(/\s+/g, "_").toLowerCase()}`}
-            className="btn-round secondary-bg-color"
-          >
-            {quoteButtonText}
-          </Button>
-        </div>
-      </Card.Body>
-    </Card>
-  );
+const SPECIALTY_QUERY = {
+  postConstruction: 'Post-Construction+Cleaning',
+  fullUnitCleanOut: 'Deep+Cleaning',
+  monthlyBuilding: 'Commercial+Cleaning'
 };
 
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
 
-  const servicesData = [
-    {
-      title: t("products_and_services.residential_cleaning_title"),
-      avif: residentialAvif,
-      webp: residentialWebp,
-      fallback: residentialJpg,
-      imgAlt: "Cleaning technician mopping the floor - Designed by Freepik",
-      width: 5906,
-      height: 3937,
-      description: t("products_and_services.residential_cleaning_description", { returnObjects: true }),
-      quoteLink: "/?service=Residential+Cleaning",
-      quoteButtonText: t("products_and_services.residential_cleaning_button"),
-      serviceSlug: "residential-cleaning"
-    },
-    {
-      title: t("products_and_services.commercial_cleaning_title"),
-      avif: commercialAvif,
-      webp: commercialWebp,
-      fallback: commercialJpg,
-      imgAlt: "Cleaners on office cleaning desks and floor - Designed by Freepik",
-      width: 4536,
-      height: 3024,
-      description: t("products_and_services.commercial_cleaning_description", { returnObjects: true }),
-      quoteLink: "/?service=Commercial+Cleaning",
-      quoteButtonText: t("products_and_services.commercial_cleaning_button"),
-      serviceSlug: "commercial-cleaning"
-    },
-    {
-      title: t("products_and_services.window_cleaning_title"),
-      avif: windowAvif,
-      webp: windowWebp,
-      fallback: windowJpg,
-      imgAlt: "Window cleaning - Designed by Freepik",
-      width: 1024,
-      height: 683,
-      description: t("products_and_services.window_cleaning_description", { returnObjects: true }),
-      quoteLink: "/?service=Window+Cleaning",
-      quoteButtonText: t("products_and_services.window_cleaning_button"),
-      serviceSlug: "window-cleaning"
-    },
-    {
-      title: t("products_and_services.carpet_cleaning_title"),
-      avif: carpetAvif,
-      webp: carpetWebp,
-      fallback: carpetJpg,
-      imgAlt: "Carpet cleaning, vacuum cleaner on carpet - Designed by Freepik",
-      width: 1024,
-      height: 683,
-      description: t("products_and_services.carpet_cleaning_description", { returnObjects: true }),
-      quoteLink: "/?service=Carpet+And+Upholstery",
-      quoteButtonText: t("products_and_services.carpet_and_upholstery_button"),
-      serviceSlug: "carpet-upholstery-cleaning"
-    },
-    {
-      title: t("products_and_services.power_washing_title"),
-      avif: pressureAvif,
-      webp: pressureWebp,
-      fallback: pressureJpg,
-      imgAlt: "Power washing - Designed by Freepik",
-      width: 1024,
-      height: 683,
-      description: t("products_and_services.power_washing_description", { returnObjects: true }),
-      quoteLink: "/?service=Power/Pressure+Washing",
-      quoteButtonText: t("products_and_services.power_pressure_washing_button"),
-      serviceSlug: "pressure-cleaning"
+  const jumpToSection = (targetId) => {
+    const section = document.getElementById(targetId);
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
-  ];
+  };
+
+  const quoteLink = (serviceQuery) => (serviceQuery
+    ? `/?service=${serviceQuery}&scrollToQuote=true`
+    : '/?scrollToQuote=true');
 
   useEffect(() => {
-    document.body.classList.add("products-services-page");
-    document.body.classList.add("sidebar-collapse");
-    document.documentElement.classList.remove("nav-open");
+    document.body.classList.add('products-services-page');
+    document.body.classList.add('sidebar-collapse');
+    document.documentElement.classList.remove('nav-open');
     window.scrollTo(0, 0);
 
     return function cleanup() {
-      document.body.classList.remove("products-services-page");
-      document.body.classList.remove("sidebar-collapse");
+      document.body.classList.remove('products-services-page');
+      document.body.classList.remove('sidebar-collapse');
     };
   }, [i18n.language]);
 
   return (
-    <section className="section-background" style={{ backgroundImage: `url(${pageBg})` }}>
-      <VisitorCounter page={"products-and-services"} />
+    <section className="section-background services-revamp" style={{ backgroundImage: `url(${pageBg})` }}>
+      <VisitorCounter page={'products-and-services'} />
 
-      <section>
-        <h1 className="title primary-color text-center mb-4 pt-5 text-bold">
-          {t("products_and_services.products_services_title")}
-        </h1>
-
-        <div className="service-selector mb-5">
-          <h2 className="title secondary-color mb-4 text-bold">
-            {t("products_and_services.our_services_title")}
-          </h2>
-
-          <p className="text-left mb-4 text-cleanar-color text-bold">
-            {t("products_and_services.our_services_description")}
+      <section className="service-selector pb-5">
+        <div className="services-hero pt-5 mb-4">
+          <h1 className="title primary-color text-bold mb-3">
+            {t('products_and_services.revamp.hero.title')}
+          </h1>
+          <p className="text-cleanar-color mb-4 services-hero-subtitle">
+            {t('products_and_services.revamp.hero.subtitle')}
           </p>
 
-          <p className="fs-6 text-cleanar-color mt-3">
-            {t("issa.prefix")}{" "}
-            <a
-              href="https://issa-canada.com/en/issa-canada-en/about-issa-canada-en"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {t("issa.linkText")}
-            </a>
-            {t("issa.suffix")}
-          </p>
-
-          <Row className="justify-content-center">
-            {servicesData.map((service, index) => (
-              <Col xs={12} md={4} key={index} className="d-flex align-items-stretch mb-1 mt-1">
-                <ServiceCard {...service} />
-              </Col>
+          <div className="d-flex flex-wrap gap-2 mb-4" aria-label={t('products_and_services.revamp.hero.trustLabel')}>
+            {t('products_and_services.revamp.hero.trustChips', { returnObjects: true }).map((chip) => (
+              <span key={chip} className="services-trust-chip">{chip}</span>
             ))}
-          </Row>
+          </div>
 
-          <div className="mt-4 text-cleanar-color">
-            <h3 className="h5 text-bold">Toronto Service Pages</h3>
-            <p className="mb-2">
-              Browse our dedicated location pages to compare cleaning options by property type and project scope.
-            </p>
-            <ul className="mb-0">
-              <li><Link to="/residential-cleaning-toronto">residential cleaning in Toronto</Link></li>
-              <li><Link to="/commercial-cleaning-toronto">commercial cleaning in Toronto</Link></li>
-              <li><Link to="/deep-cleaning-toronto">deep cleaning in Toronto</Link></li>
-              <li><Link to="/move-in-move-out-cleaning-toronto">move-in and move-out cleaning in Toronto</Link></li>
-              <li><Link to="/carpet-upholstery-cleaning-toronto">carpet and upholstery cleaning in Toronto</Link></li>
-            </ul>
+          <div className="d-flex flex-wrap gap-2">
+            <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color">
+              {t('products_and_services.revamp.hero.primaryCta')}
+            </Button>
+            <Button variant="outline-secondary" className="btn-round" onClick={() => jumpToSection('services')}>
+              {t('products_and_services.revamp.hero.secondaryCta')}
+            </Button>
           </div>
         </div>
 
-        <div className="product-selector">
-          <h2 className="title primary-color mb-4 text-bold">
-            {t("products_and_services.our_products_title")}
-          </h2>
+        <nav className="services-category-nav mb-4" aria-label={t('products_and_services.revamp.categoryNav.ariaLabel')}>
+          {categoryAnchors.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className="services-category-chip"
+              onClick={() => jumpToSection(item.target)}
+            >
+              {t(`products_and_services.revamp.categoryNav.${item.key}`)}
+            </button>
+          ))}
+        </nav>
 
-          <Row className="g-4 justify-content-center">
-            <Col xs={12} md={4} className="d-flex align-items-stretch">
-              <Card className="h-100 card-border shadow-sm">
-                <Card.Body className="d-flex flex-column">
-                  <Card.Title as="h3" className="text-bold primary-color">
-                    {t("products_and_services.coming_soon")}
-                  </Card.Title>
-                </Card.Body>
-              </Card>
-            </Col>
+        <section id="services" className="mb-5">
+          <h2 id="core-services" className="title secondary-color text-bold mb-3">
+            {t('products_and_services.revamp.core.title')}
+          </h2>
+          <Row className="g-3">
+            {Object.entries(t('products_and_services.revamp.core.items', { returnObjects: true })).map(([key, service]) => (
+              <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
+                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                  <Card.Body className="d-flex flex-column">
+                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold mb-2">{service.name}</Card.Title>
+                    <Card.Text className="mb-2 text-muted">{service.description}</Card.Text>
+                    <p className="small mb-3 text-cleanar-color"><strong>{t('products_and_services.revamp.core.bestForLabel')}</strong> {service.bestFor}</p>
+                    <Button as={Link} to={quoteLink(CORE_SERVICE_QUERY[key])} className="btn-round secondary-bg-color mt-auto">
+                      {t('products_and_services.revamp.core.cta')}
+                    </Button>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
           </Row>
-        </div>
+        </section>
+
+        <section id="cleaning-packages" className="mb-5">
+          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
+          <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
+          <Row className="g-3">
+            {t('products_and_services.revamp.packages.items', { returnObjects: true }).map((pkg) => (
+              <Col xs={12} md={4} key={pkg.name}>
+                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                  <Card.Body>
+                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{pkg.name}</Card.Title>
+                    <p className="text-muted mb-2">{pkg.pricing}</p>
+                    <p className="small mb-0">{pkg.note}</p>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+        <section id="add-ons" className="mb-5">
+          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
+          <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
+          <Row className="g-3">
+            {Object.values(t('products_and_services.revamp.addons.groups', { returnObjects: true })).map((group) => (
+              <Col xs={12} md={6} key={group.title}>
+                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                  <Card.Body>
+                    <Card.Title as="h3" className="h6 text-cleanar-color text-bold">{group.title}</Card.Title>
+                    <ul className="mb-0 services-compact-list">
+                      {group.items.map((item) => <li key={item}>{item}</li>)}
+                    </ul>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+        <section id="carpet-upholstery" className="mb-5">
+          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
+          <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
+          <Row className="g-3">
+            {Object.values(t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true })).map((column) => (
+              <Col xs={12} md={6} key={column.title}>
+                <Card className="h-100 shadow-sm bg-transparent service-revamp-card">
+                  <Card.Body>
+                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{column.title}</Card.Title>
+                    <ul className="mb-0 services-compact-list">
+                      {column.items.map((item) => <li key={item}>{item}</li>)}
+                    </ul>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+        <section id="specialty-services" className="mb-5">
+          <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
+          <Row className="g-3">
+            {Object.entries(t('products_and_services.revamp.specialty.items', { returnObjects: true })).map(([key, item]) => (
+              <Col xs={12} md={4} key={key}>
+                <Card className="h-100 shadow premium-service-card">
+                  <Card.Body className="d-flex flex-column">
+                    <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
+                    <Card.Text className="text-muted mb-3">{item.description}</Card.Text>
+                    <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color mt-auto">
+                      {t('products_and_services.revamp.specialty.cta')}
+                    </Button>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+        <section className="mb-5">
+          <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
+          <ol className="services-steps-list">
+            {t('products_and_services.revamp.howItWorks.steps', { returnObjects: true }).map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="services-final-cta">
+          <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
+          <p className="mb-3 text-cleanar-color">{t('products_and_services.revamp.finalCta.description')}</p>
+          <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color">
+            {t('products_and_services.revamp.finalCta.button')}
+          </Button>
+        </section>
       </section>
     </section>
   );

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -253,7 +253,7 @@ const ProductsAndServices = () => {
             <div id="services-section-core" hidden={isMobile && !openSections.core} className="services-collapsible-content">
               <Row className="g-3">
                 {Object.entries(coreItems).map(([key, service]) => (
-                  <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
+                  <Col xs={12} sm={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
                     <Card className="h-100 service-revamp-card">
                       <Card.Body className="d-flex flex-column">
                         <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.core')}</span>
@@ -305,7 +305,7 @@ const ProductsAndServices = () => {
               <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
               <Row className="g-3">
                 {packageItems.map((pkg) => (
-                  <Col xs={12} md={4} key={pkg.name}>
+                  <Col xs={12} sm={6} lg={4} key={pkg.name}>
                     <Card className="h-100 service-revamp-card service-package-card">
                       <Card.Body>
                         <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.packages')}</span>
@@ -346,7 +346,7 @@ const ProductsAndServices = () => {
               <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
               <Row className="g-3">
                 {Object.values(addonGroups).map((group) => (
-                  <Col xs={12} md={6} key={group.title}>
+                  <Col xs={12} sm={6} key={group.title}>
                     <Card className="h-100 service-revamp-card">
                       <Card.Body>
                         <Card.Title as="h3" className="h6 text-cleanar-color text-bold">{group.title}</Card.Title>
@@ -436,7 +436,7 @@ const ProductsAndServices = () => {
             <div id="services-section-specialty" hidden={isMobile && !openSections.specialty} className="services-collapsible-content">
               <Row className="g-3">
                 {Object.entries(specialtyItems).map(([key, item]) => (
-                  <Col xs={12} md={4} key={key}>
+                  <Col xs={12} sm={6} lg={4} key={key}>
                     <Card className="h-100 premium-service-card">
                       <Card.Body className="d-flex flex-column">
                         <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next';
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
 import pageBg from "/src/assets/img/bg1.png";
 
+const MOBILE_MAX_WIDTH = 575;
+
 const categoryAnchors = [
   { key: 'core', target: 'core-services' },
   { key: 'packages', target: 'cleaning-packages' },
@@ -42,16 +44,45 @@ const SERVICE_ROUTE_BY_KEY = {
   monthlyBuilding: '/services/monthly-building-amenities-cleaning'
 };
 
+const sectionKeys = ['core', 'packages', 'addons', 'carpetUpholstery', 'specialty'];
+
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
   const [activeCategory, setActiveCategory] = useState('core');
+  const [isMobile, setIsMobile] = useState(false);
+  const [mobileOpenSections, setMobileOpenSections] = useState({
+    core: true,
+    packages: false,
+    addons: false,
+    carpetUpholstery: false,
+    specialty: false
+  });
 
+  const coreItems = t('products_and_services.revamp.core.items', { returnObjects: true });
+  const packageItems = t('products_and_services.revamp.packages.items', { returnObjects: true });
+  const addonGroups = t('products_and_services.revamp.addons.groups', { returnObjects: true });
+  const carpetColumns = t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true });
+  const specialtyItems = t('products_and_services.revamp.specialty.items', { returnObjects: true });
   const howItWorksSteps = t('products_and_services.revamp.howItWorks.steps', { returnObjects: true });
   const howItWorksDescriptions = t('products_and_services.revamp.howItWorks.stepDescriptions', { returnObjects: true });
+
   const howItWorksItems = useMemo(
     () => howItWorksSteps.map((title, index) => ({ title, description: howItWorksDescriptions[index] || '' })),
     [howItWorksDescriptions, howItWorksSteps]
   );
+
+  const sectionSummaries = useMemo(() => {
+    const addonsCount = Object.values(addonGroups).reduce((total, group) => total + group.items.length, 0);
+    const carpetCount = Object.values(carpetColumns).reduce((total, column) => total + column.items.length, 0);
+
+    return {
+      core: t('products_and_services.revamp.mobileSummaries.core', { count: Object.keys(coreItems).length }),
+      packages: t('products_and_services.revamp.mobileSummaries.packages', { count: packageItems.length }),
+      addons: t('products_and_services.revamp.mobileSummaries.addons', { count: addonsCount }),
+      carpetUpholstery: t('products_and_services.revamp.mobileSummaries.carpetUpholstery', { count: carpetCount }),
+      specialty: t('products_and_services.revamp.mobileSummaries.specialty', { count: Object.keys(specialtyItems).length })
+    };
+  }, [addonGroups, carpetColumns, coreItems, packageItems.length, specialtyItems, t]);
 
   const jumpToSection = (targetId) => {
     const section = document.getElementById(targetId);
@@ -65,6 +96,30 @@ const ProductsAndServices = () => {
     : '/?scrollToQuote=true');
 
   const getDisplayListItem = (item) => (item.includes('–') ? item.split('–')[1].trim() : item);
+
+  const handleSectionToggle = (sectionKey) => {
+    setMobileOpenSections((prev) => {
+      if (prev[sectionKey]) {
+        return prev;
+      }
+
+      const nextState = sectionKeys.reduce((acc, key) => ({ ...acc, [key]: false }), {});
+      nextState[sectionKey] = true;
+      return nextState;
+    });
+  };
+
+  const isSectionExpanded = (sectionKey) => !isMobile || !!mobileOpenSections[sectionKey];
+
+  useEffect(() => {
+    const updateViewport = () => {
+      setIsMobile(window.innerWidth <= MOBILE_MAX_WIDTH);
+    };
+
+    updateViewport();
+    window.addEventListener('resize', updateViewport);
+    return () => window.removeEventListener('resize', updateViewport);
+  }, []);
 
   useEffect(() => {
     document.body.classList.add('products-services-page');
@@ -85,43 +140,43 @@ const ProductsAndServices = () => {
       <Container className="services-page-shell">
         <section className="service-selector pb-5">
           <div id="services-top" className="services-hero pt-5 mb-4">
-          <h1 className="title primary-color text-bold mb-3">
-            {t('products_and_services.revamp.hero.title')}
-          </h1>
-          <p className="text-cleanar-color mb-4 services-hero-subtitle">
-            {t('products_and_services.revamp.hero.subtitle')}
-          </p>
+            <h1 className="title primary-color text-bold mb-3">
+              {t('products_and_services.revamp.hero.title')}
+            </h1>
+            <p className="text-cleanar-color mb-4 services-hero-subtitle">
+              {t('products_and_services.revamp.hero.subtitle')}
+            </p>
 
-          <div className="d-flex flex-wrap gap-2 mb-4" aria-label={t('products_and_services.revamp.hero.trustLabel')}>
-            {t('products_and_services.revamp.hero.trustChips', { returnObjects: true }).map((chip) => (
-              <span key={chip} className="services-trust-chip">{chip}</span>
-            ))}
-          </div>
+            <div className="d-flex flex-wrap gap-2 mb-4 services-trust-grid" aria-label={t('products_and_services.revamp.hero.trustLabel')}>
+              {t('products_and_services.revamp.hero.trustChips', { returnObjects: true }).map((chip) => (
+                <span key={chip} className="services-trust-chip">{chip}</span>
+              ))}
+            </div>
 
-          <div className="d-flex flex-wrap gap-2 services-hero-cta-wrap">
-            <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-hero-primary-cta">
-              {t('products_and_services.revamp.hero.primaryCta')}
-            </Button>
-            <Button variant="outline-secondary" className="btn-round services-hero-secondary-cta" onClick={() => jumpToSection('services')}>
-              {t('products_and_services.revamp.hero.secondaryCta')}
-            </Button>
+            <div className="d-flex flex-wrap gap-2 services-hero-cta-wrap">
+              <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-hero-primary-cta">
+                {t('products_and_services.revamp.hero.primaryCta')}
+              </Button>
+              <Button variant="outline-secondary" className="btn-round services-hero-secondary-cta" onClick={() => jumpToSection('services')}>
+                {t('products_and_services.revamp.hero.secondaryCta')}
+              </Button>
+            </div>
           </div>
-        </div>
 
           <nav className="services-category-nav mb-4" aria-label={t('products_and_services.revamp.categoryNav.ariaLabel')}>
-          {categoryAnchors.map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              className={`services-category-chip ${activeCategory === item.key ? 'is-active' : ''}`}
-              onClick={() => {
-                setActiveCategory(item.key);
-                jumpToSection(item.target);
-              }}
-            >
-              {t(`products_and_services.revamp.categoryNav.${item.key}`)}
-            </button>
-          ))}
+            {categoryAnchors.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                className={`services-category-chip ${activeCategory === item.key ? 'is-active' : ''}`}
+                onClick={() => {
+                  setActiveCategory(item.key);
+                  jumpToSection(item.target);
+                }}
+              >
+                {t(`products_and_services.revamp.categoryNav.${item.key}`)}
+              </button>
+            ))}
           </nav>
 
           <section id="services" className="mb-5 services-section-panel">
@@ -129,184 +184,253 @@ const ProductsAndServices = () => {
               <h2 id="core-services" className="title secondary-color text-bold mb-3">
                 {t('products_and_services.revamp.core.title')}
               </h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <Row className="g-3">
-            {Object.entries(t('products_and_services.revamp.core.items', { returnObjects: true })).map(([key, service]) => (
-              <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
-                <Card className="h-100 service-revamp-card">
-                  <Card.Body className="d-flex flex-column">
-                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.core')}</span>
-                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold mb-2">{service.name}</Card.Title>
-                    <Card.Text className="mb-2 text-muted">{service.description}</Card.Text>
-                    <p className="small mb-3 text-cleanar-color"><strong>{t('products_and_services.revamp.core.bestForLabel')}</strong> {service.bestFor}</p>
-                    <div className="services-card-actions mt-auto">
-                      {SERVICE_ROUTE_BY_KEY[key] ? (
-                        <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
-                          {t('products_and_services.revamp.learnMore')}
-                        </Link>
-                      ) : null}
-                      <Button as={Link} to={quoteLink(CORE_SERVICE_QUERY[key])} className="btn-round secondary-bg-color">
-                        {t('products_and_services.revamp.core.cta')}
-                      </Button>
-                    </div>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('core')}
+                aria-controls="core-services-content"
+                onClick={() => handleSectionToggle('core')}
+              >
+                <span>{sectionSummaries.core}</span>
+                <span>{isSectionExpanded('core') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="core-services-content" className={`services-collapsible-content ${isSectionExpanded('core') ? 'is-open' : ''}`}>
+              <Row className="g-3">
+                {Object.entries(coreItems).map(([key, service]) => (
+                  <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
+                    <Card className="h-100 service-revamp-card">
+                      <Card.Body className="d-flex flex-column">
+                        <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.core')}</span>
+                        <Card.Title as="h3" className="h5 text-cleanar-color text-bold mb-2">{service.name}</Card.Title>
+                        <Card.Text className="mb-2 text-muted services-card-description">{service.description}</Card.Text>
+                        <p className="small mb-3 text-cleanar-color"><strong>{t('products_and_services.revamp.core.bestForLabel')}</strong> {service.bestFor}</p>
+                        <div className="services-card-actions mt-auto">
+                          {SERVICE_ROUTE_BY_KEY[key] ? (
+                            <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
+                              {t('products_and_services.revamp.learnMore')}
+                            </Link>
+                          ) : null}
+                          <Button as={Link} to={quoteLink(CORE_SERVICE_QUERY[key])} className="btn-round secondary-bg-color">
+                            {t('products_and_services.revamp.core.cta')}
+                          </Button>
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            </div>
+          </section>
 
           <section id="cleaning-packages" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
-          <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
-          <Row className="g-3">
-            {t('products_and_services.revamp.packages.items', { returnObjects: true }).map((pkg) => (
-              <Col xs={12} md={4} key={pkg.name}>
-                <Card className="h-100 service-revamp-card service-package-card">
-                  <Card.Body>
-                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.packages')}</span>
-                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{pkg.name}</Card.Title>
-                    <p className="text-muted mb-2">{pkg.pricing}</p>
-                    <p className="small mb-0">{pkg.note}</p>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('packages')}
+                aria-controls="packages-content"
+                onClick={() => handleSectionToggle('packages')}
+              >
+                <span>{sectionSummaries.packages}</span>
+                <span>{isSectionExpanded('packages') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="packages-content" className={`services-collapsible-content ${isSectionExpanded('packages') ? 'is-open' : ''}`}>
+              <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
+              <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
+              <Row className="g-3">
+                {packageItems.map((pkg) => (
+                  <Col xs={12} md={4} key={pkg.name}>
+                    <Card className="h-100 service-revamp-card service-package-card">
+                      <Card.Body>
+                        <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.packages')}</span>
+                        <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{pkg.name}</Card.Title>
+                        <p className="text-muted mb-2">{pkg.pricing}</p>
+                        <p className="small mb-0">{pkg.note}</p>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            </div>
+          </section>
 
           <section id="add-ons" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
-          <Row className="g-3">
-            {Object.values(t('products_and_services.revamp.addons.groups', { returnObjects: true })).map((group) => (
-              <Col xs={12} md={6} key={group.title}>
-                <Card className="h-100 service-revamp-card">
-                  <Card.Body>
-                    <Card.Title as="h3" className="h6 text-cleanar-color text-bold">{group.title}</Card.Title>
-                    <div className="services-pills-list">
-                      {group.items.map((item) => <span key={item} className="services-item-pill">{item}</span>)}
-                    </div>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('addons')}
+                aria-controls="addons-content"
+                onClick={() => handleSectionToggle('addons')}
+              >
+                <span>{sectionSummaries.addons}</span>
+                <span>{isSectionExpanded('addons') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="addons-content" className={`services-collapsible-content ${isSectionExpanded('addons') ? 'is-open' : ''}`}>
+              <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
+              <Row className="g-3">
+                {Object.values(addonGroups).map((group) => (
+                  <Col xs={12} md={6} key={group.title}>
+                    <Card className="h-100 service-revamp-card">
+                      <Card.Body>
+                        <Card.Title as="h3" className="h6 text-cleanar-color text-bold">{group.title}</Card.Title>
+                        <div className="services-pills-list">
+                          {group.items.map((item) => <span key={item} className="services-item-pill">{item}</span>)}
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            </div>
+          </section>
 
           <section id="carpet-upholstery" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
-          <Row className="g-3">
-            {Object.entries(t('products_and_services.revamp.carpetUpholstery.columns', { returnObjects: true })).map(([key, column]) => (
-              <Col xs={12} md={6} key={column.title}>
-                <Card className="h-100 service-revamp-card service-split-card">
-                  <Card.Body>
-                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.carpetUpholstery')}</span>
-                    <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{column.title}</Card.Title>
-                    {SERVICE_ROUTE_BY_KEY[`${key}Cleaning`] ? (
-                      <Link to={SERVICE_ROUTE_BY_KEY[`${key}Cleaning`]} className="services-inline-link text-cleanar-color text-bold">
-                        {t('products_and_services.revamp.learnMore')}
-                      </Link>
-                    ) : null}
-                    <div className="services-pills-list">
-                      {column.items.map((item) => <span key={item} className="services-item-pill">{getDisplayListItem(item)}</span>)}
-                    </div>
-                    <Button as={Link} to={quoteLink(key === 'carpet' ? CORE_SERVICE_QUERY.carpetCleaning : CORE_SERVICE_QUERY.upholsteryCleaning)} className="btn-round secondary-bg-color mt-3">
-                      {t('products_and_services.revamp.core.cta')}
-                    </Button>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('carpetUpholstery')}
+                aria-controls="carpet-upholstery-content"
+                onClick={() => handleSectionToggle('carpetUpholstery')}
+              >
+                <span>{sectionSummaries.carpetUpholstery}</span>
+                <span>{isSectionExpanded('carpetUpholstery') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="carpet-upholstery-content" className={`services-collapsible-content ${isSectionExpanded('carpetUpholstery') ? 'is-open' : ''}`}>
+              <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
+              <Row className="g-3">
+                {Object.entries(carpetColumns).map(([key, column]) => (
+                  <Col xs={12} md={6} key={column.title}>
+                    <Card className="h-100 service-revamp-card service-split-card">
+                      <Card.Body>
+                        <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.carpetUpholstery')}</span>
+                        <Card.Title as="h3" className="h5 text-cleanar-color text-bold">{column.title}</Card.Title>
+                        {SERVICE_ROUTE_BY_KEY[`${key}Cleaning`] ? (
+                          <Link to={SERVICE_ROUTE_BY_KEY[`${key}Cleaning`]} className="services-inline-link text-cleanar-color text-bold">
+                            {t('products_and_services.revamp.learnMore')}
+                          </Link>
+                        ) : null}
+                        <div className="services-pills-list">
+                          {column.items.map((item) => <span key={item} className="services-item-pill">{getDisplayListItem(item)}</span>)}
+                        </div>
+                        <Button as={Link} to={quoteLink(key === 'carpet' ? CORE_SERVICE_QUERY.carpetCleaning : CORE_SERVICE_QUERY.upholsteryCleaning)} className="btn-round secondary-bg-color mt-3">
+                          {t('products_and_services.revamp.core.cta')}
+                        </Button>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            </div>
+          </section>
 
           <section id="specialty-services" className="mb-5 services-section-panel services-section-panel-premium">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <Row className="g-3">
-            {Object.entries(t('products_and_services.revamp.specialty.items', { returnObjects: true })).map(([key, item]) => (
-              <Col xs={12} md={4} key={key}>
-                <Card className="h-100 premium-service-card">
-                  <Card.Body className="d-flex flex-column">
-                    <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>
-                    <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
-                    <Card.Text className="text-muted mb-3">{item.description}</Card.Text>
-                    <div className="services-card-actions mt-auto">
-                      {SERVICE_ROUTE_BY_KEY[key] ? (
-                        <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
-                          {t('products_and_services.revamp.learnMore')}
-                        </Link>
-                      ) : null}
-                      <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color">
-                        {t('products_and_services.revamp.specialty.cta')}
-                      </Button>
-                    </div>
-                  </Card.Body>
-                </Card>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('specialty')}
+                aria-controls="specialty-content"
+                onClick={() => handleSectionToggle('specialty')}
+              >
+                <span>{sectionSummaries.specialty}</span>
+                <span>{isSectionExpanded('specialty') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="specialty-content" className={`services-collapsible-content ${isSectionExpanded('specialty') ? 'is-open' : ''}`}>
+              <Row className="g-3">
+                {Object.entries(specialtyItems).map(([key, item]) => (
+                  <Col xs={12} md={4} key={key}>
+                    <Card className="h-100 premium-service-card">
+                      <Card.Body className="d-flex flex-column">
+                        <span className="service-card-kicker">{t('products_and_services.revamp.categoryNav.specialty')}</span>
+                        <Card.Title as="h3" className="h5 text-bold">{item.name}</Card.Title>
+                        <Card.Text className="text-muted mb-3 services-card-description">{item.description}</Card.Text>
+                        <div className="services-card-actions mt-auto">
+                          {SERVICE_ROUTE_BY_KEY[key] ? (
+                            <Link to={SERVICE_ROUTE_BY_KEY[key]} className="services-inline-link text-cleanar-color text-bold">
+                              {t('products_and_services.revamp.learnMore')}
+                            </Link>
+                          ) : null}
+                          <Button as={Link} to={quoteLink(SPECIALTY_QUERY[key])} className="btn-round secondary-bg-color">
+                            {t('products_and_services.revamp.specialty.cta')}
+                          </Button>
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  </Col>
+                ))}
+              </Row>
+            </div>
+          </section>
 
-          <section className="mb-5 services-section-panel">
+          <section className="mb-4 services-section-panel services-how-compact">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <Row className="g-3">
-            {howItWorksItems.map((step, index) => (
-              <Col xs={12} md={6} lg={3} key={step.title}>
-                <article className="services-process-card h-100">
-                  <span className="services-process-number">{index + 1}</span>
-                  <h3 className="h6 text-cleanar-color text-bold mt-3 mb-2">{step.title}</h3>
-                  <p className="mb-0 text-muted small">{step.description}</p>
-                </article>
-              </Col>
-            ))}
-          </Row>
-        </section>
+            <Row className="g-2 g-md-3">
+              {howItWorksItems.map((step, index) => (
+                <Col xs={6} md={6} lg={3} key={step.title}>
+                  <article className="services-process-card h-100">
+                    <span className="services-process-number">{index + 1}</span>
+                    <h3 className="h6 text-cleanar-color text-bold mt-2 mb-1">{step.title}</h3>
+                    <p className="mb-0 text-muted small">{step.description}</p>
+                  </article>
+                </Col>
+              ))}
+            </Row>
+          </section>
 
           <section className="services-final-cta">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
-            <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
-              {t('products_and_services.revamp.backToTop')}
-            </button>
+              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+                {t('products_and_services.revamp.backToTop')}
+              </button>
             </div>
-          <p className="mb-3 text-cleanar-color">{t('products_and_services.revamp.finalCta.description')}</p>
-          <p className="services-final-cta-support text-muted mb-3">{t('products_and_services.revamp.finalCta.supportText')}</p>
-          <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-final-cta-button">
-            {t('products_and_services.revamp.finalCta.button')}
-          </Button>
+            <p className="mb-2 text-cleanar-color">{t('products_and_services.revamp.finalCta.description')}</p>
+            <p className="services-final-cta-support text-muted mb-3">{t('products_and_services.revamp.finalCta.supportText')}</p>
+            <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-final-cta-button">
+              {t('products_and_services.revamp.finalCta.button')}
+            </Button>
           </section>
-
         </section>
       </Container>
     </section>

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import VisitorCounter from "/src/components/Pages/Management/VisitorCounter.jsx";
 import pageBg from "/src/assets/img/bg1.png";
 
-const MOBILE_MAX_WIDTH = 575;
+const MOBILE_MAX_WIDTH = 767;
 
 const categoryAnchors = [
   { key: 'core', target: 'core-services' },
@@ -44,18 +44,20 @@ const SERVICE_ROUTE_BY_KEY = {
   monthlyBuilding: '/services/monthly-building-amenities-cleaning'
 };
 
-const sectionKeys = ['core', 'packages', 'addons', 'carpetUpholstery', 'specialty'];
+const sectionKeys = ['core', 'packages', 'addons', 'carpetUpholstery', 'specialty', 'howItWorks'];
 
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
   const [activeCategory, setActiveCategory] = useState('core');
   const [isMobile, setIsMobile] = useState(false);
+  const [headerOffset, setHeaderOffset] = useState(120);
   const [mobileOpenSections, setMobileOpenSections] = useState({
     core: true,
     packages: false,
     addons: false,
     carpetUpholstery: false,
-    specialty: false
+    specialty: false,
+    howItWorks: false
   });
 
   const coreItems = t('products_and_services.revamp.core.items', { returnObjects: true });
@@ -71,23 +73,48 @@ const ProductsAndServices = () => {
     [howItWorksDescriptions, howItWorksSteps]
   );
 
-  const sectionSummaries = useMemo(() => {
+  const sectionMeta = useMemo(() => {
     const addonsCount = Object.values(addonGroups).reduce((total, group) => total + group.items.length, 0);
     const carpetCount = Object.values(carpetColumns).reduce((total, column) => total + column.items.length, 0);
 
     return {
-      core: t('products_and_services.revamp.mobileSummaries.core', { count: Object.keys(coreItems).length }),
-      packages: t('products_and_services.revamp.mobileSummaries.packages', { count: packageItems.length }),
-      addons: t('products_and_services.revamp.mobileSummaries.addons', { count: addonsCount }),
-      carpetUpholstery: t('products_and_services.revamp.mobileSummaries.carpetUpholstery', { count: carpetCount }),
-      specialty: t('products_and_services.revamp.mobileSummaries.specialty', { count: Object.keys(specialtyItems).length })
+      core: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.core'),
+        count: Object.keys(coreItems).length
+      },
+      packages: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.packages'),
+        count: packageItems.length
+      },
+      addons: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.addons'),
+        count: addonsCount
+      },
+      carpetUpholstery: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.carpetUpholstery'),
+        count: carpetCount
+      },
+      specialty: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.specialty'),
+        count: Object.keys(specialtyItems).length
+      },
+      howItWorks: {
+        summary: t('products_and_services.revamp.mobileSectionDescriptions.howItWorks'),
+        count: howItWorksItems.length
+      }
     };
-  }, [addonGroups, carpetColumns, coreItems, packageItems.length, specialtyItems, t]);
+  }, [addonGroups, carpetColumns, coreItems, howItWorksItems.length, packageItems.length, specialtyItems, t]);
 
-  const jumpToSection = (targetId) => {
+  const getHeaderHeight = () => {
+    const header = document.querySelector('.fixed-top-container') || document.querySelector('.navbar');
+    return header ? header.getBoundingClientRect().height : 90;
+  };
+
+  const scrollToSection = (targetId) => {
     const section = document.getElementById(targetId);
     if (section) {
-      section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const y = section.getBoundingClientRect().top + window.pageYOffset - getHeaderHeight() - 16;
+      window.scrollTo({ top: y, behavior: 'smooth' });
     }
   };
 
@@ -99,21 +126,26 @@ const ProductsAndServices = () => {
 
   const handleSectionToggle = (sectionKey) => {
     setMobileOpenSections((prev) => {
-      if (prev[sectionKey]) {
-        return prev;
-      }
-
-      const nextState = sectionKeys.reduce((acc, key) => ({ ...acc, [key]: false }), {});
-      nextState[sectionKey] = true;
+      const nextState = sectionKeys.reduce((acc, key) => ({ ...acc, [key]: key === sectionKey ? !prev[sectionKey] : prev[key] }), {});
       return nextState;
     });
   };
 
   const isSectionExpanded = (sectionKey) => !isMobile || !!mobileOpenSections[sectionKey];
 
+  const openSectionAndScroll = (sectionKey, targetId) => {
+    if (isMobile && !isSectionExpanded(sectionKey)) {
+      setMobileOpenSections((prev) => ({ ...prev, [sectionKey]: true }));
+      window.setTimeout(() => scrollToSection(targetId), 110);
+      return;
+    }
+    scrollToSection(targetId);
+  };
+
   useEffect(() => {
     const updateViewport = () => {
       setIsMobile(window.innerWidth <= MOBILE_MAX_WIDTH);
+      setHeaderOffset(getHeaderHeight() + 16);
     };
 
     updateViewport();
@@ -133,8 +165,22 @@ const ProductsAndServices = () => {
     };
   }, [i18n.language]);
 
+  useEffect(() => {
+    if (!window.location.hash) {
+      return;
+    }
+    const hashId = window.location.hash.replace('#', '');
+    window.setTimeout(() => scrollToSection(hashId), 80);
+  }, []);
+
   return (
-    <section className="section-background services-revamp" style={{ backgroundImage: `url(${pageBg})` }}>
+    <section
+      className="section-background services-revamp"
+      style={{
+        backgroundImage: `url(${pageBg})`,
+        '--services-scroll-offset': `${headerOffset}px`
+      }}
+    >
       <VisitorCounter page={'products-and-services'} />
 
       <Container className="services-page-shell">
@@ -171,7 +217,7 @@ const ProductsAndServices = () => {
                 className={`services-category-chip ${activeCategory === item.key ? 'is-active' : ''}`}
                 onClick={() => {
                   setActiveCategory(item.key);
-                  jumpToSection(item.target);
+                  openSectionAndScroll(item.key, item.target);
                 }}
               >
                 {t(`products_and_services.revamp.categoryNav.${item.key}`)}
@@ -184,7 +230,7 @@ const ProductsAndServices = () => {
               <h2 id="core-services" className="title secondary-color text-bold mb-3">
                 {t('products_and_services.revamp.core.title')}
               </h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
@@ -196,7 +242,10 @@ const ProductsAndServices = () => {
                 aria-controls="core-services-content"
                 onClick={() => handleSectionToggle('core')}
               >
-                <span>{sectionSummaries.core}</span>
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.core.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.core.count })}</small>
+                </span>
                 <span>{isSectionExpanded('core') ? '−' : '+'}</span>
               </button>
             ) : null}
@@ -231,7 +280,7 @@ const ProductsAndServices = () => {
           <section id="cleaning-packages" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.packages.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
@@ -243,7 +292,10 @@ const ProductsAndServices = () => {
                 aria-controls="packages-content"
                 onClick={() => handleSectionToggle('packages')}
               >
-                <span>{sectionSummaries.packages}</span>
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.packages.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.packages.count })}</small>
+                </span>
                 <span>{isSectionExpanded('packages') ? '−' : '+'}</span>
               </button>
             ) : null}
@@ -270,7 +322,7 @@ const ProductsAndServices = () => {
           <section id="add-ons" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.addons.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
@@ -282,7 +334,10 @@ const ProductsAndServices = () => {
                 aria-controls="addons-content"
                 onClick={() => handleSectionToggle('addons')}
               >
-                <span>{sectionSummaries.addons}</span>
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.addons.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.addons.count })}</small>
+                </span>
                 <span>{isSectionExpanded('addons') ? '−' : '+'}</span>
               </button>
             ) : null}
@@ -308,7 +363,7 @@ const ProductsAndServices = () => {
           <section id="carpet-upholstery" className="mb-5 services-section-panel">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.carpetUpholstery.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
@@ -320,7 +375,10 @@ const ProductsAndServices = () => {
                 aria-controls="carpet-upholstery-content"
                 onClick={() => handleSectionToggle('carpetUpholstery')}
               >
-                <span>{sectionSummaries.carpetUpholstery}</span>
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.carpetUpholstery.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.carpetUpholstery.count })}</small>
+                </span>
                 <span>{isSectionExpanded('carpetUpholstery') ? '−' : '+'}</span>
               </button>
             ) : null}
@@ -355,7 +413,7 @@ const ProductsAndServices = () => {
           <section id="specialty-services" className="mb-5 services-section-panel services-section-panel-premium">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.specialty.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
@@ -367,7 +425,10 @@ const ProductsAndServices = () => {
                 aria-controls="specialty-content"
                 onClick={() => handleSectionToggle('specialty')}
               >
-                <span>{sectionSummaries.specialty}</span>
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.specialty.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.specialty.count })}</small>
+                </span>
                 <span>{isSectionExpanded('specialty') ? '−' : '+'}</span>
               </button>
             ) : null}
@@ -398,30 +459,47 @@ const ProductsAndServices = () => {
             </div>
           </section>
 
-          <section className="mb-4 services-section-panel services-how-compact">
+          <section id="how-it-works" className="mb-4 services-section-panel services-how-compact">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-3">{t('products_and_services.revamp.howItWorks.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>
-            <Row className="g-2 g-md-3">
-              {howItWorksItems.map((step, index) => (
-                <Col xs={6} md={6} lg={3} key={step.title}>
-                  <article className="services-process-card h-100">
-                    <span className="services-process-number">{index + 1}</span>
-                    <h3 className="h6 text-cleanar-color text-bold mt-2 mb-1">{step.title}</h3>
-                    <p className="mb-0 text-muted small">{step.description}</p>
-                  </article>
-                </Col>
-              ))}
-            </Row>
+            {isMobile ? (
+              <button
+                type="button"
+                className="services-mobile-toggle"
+                aria-expanded={isSectionExpanded('howItWorks')}
+                aria-controls="how-it-works-content"
+                onClick={() => setMobileOpenSections((prev) => ({ ...prev, howItWorks: !prev.howItWorks }))}
+              >
+                <span className="services-mobile-toggle-copy">
+                  <span>{sectionMeta.howItWorks.summary}</span>
+                  <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.howItWorks.count })}</small>
+                </span>
+                <span>{isSectionExpanded('howItWorks') ? '−' : '+'}</span>
+              </button>
+            ) : null}
+            <div id="how-it-works-content" className={`services-collapsible-content ${isSectionExpanded('howItWorks') ? 'is-open' : ''}`}>
+              <Row className="g-2 g-md-3">
+                {howItWorksItems.map((step, index) => (
+                  <Col xs={6} md={6} lg={3} key={step.title}>
+                    <article className="services-process-card h-100">
+                      <span className="services-process-number">{index + 1}</span>
+                      <h3 className="h6 text-cleanar-color text-bold mt-2 mb-1">{step.title}</h3>
+                      <p className="mb-0 text-muted small">{step.description}</p>
+                    </article>
+                  </Col>
+                ))}
+              </Row>
+            </div>
           </section>
 
           <section className="services-final-cta">
             <div className="services-section-head">
               <h2 className="title secondary-color text-bold mb-2">{t('products_and_services.revamp.finalCta.title')}</h2>
-              <button type="button" className="services-back-to-top" onClick={() => jumpToSection('services-top')}>
+              <button type="button" className="services-back-to-top" onClick={() => scrollToSection('services-top')}>
                 {t('products_and_services.revamp.backToTop')}
               </button>
             </div>

--- a/client/src/components/Pages/Navigation/ProductsAndServices.jsx
+++ b/client/src/components/Pages/Navigation/ProductsAndServices.jsx
@@ -44,14 +44,12 @@ const SERVICE_ROUTE_BY_KEY = {
   monthlyBuilding: '/services/monthly-building-amenities-cleaning'
 };
 
-const sectionKeys = ['core', 'packages', 'addons', 'carpetUpholstery', 'specialty', 'howItWorks'];
-
 const ProductsAndServices = () => {
   const { t, i18n } = useTranslation();
   const [activeCategory, setActiveCategory] = useState('core');
   const [isMobile, setIsMobile] = useState(false);
   const [headerOffset, setHeaderOffset] = useState(120);
-  const [mobileOpenSections, setMobileOpenSections] = useState({
+  const [openSections, setOpenSections] = useState({
     core: true,
     packages: false,
     addons: false,
@@ -124,22 +122,25 @@ const ProductsAndServices = () => {
 
   const getDisplayListItem = (item) => (item.includes('–') ? item.split('–')[1].trim() : item);
 
-  const handleSectionToggle = (sectionKey) => {
-    setMobileOpenSections((prev) => {
-      const nextState = sectionKeys.reduce((acc, key) => ({ ...acc, [key]: key === sectionKey ? !prev[sectionKey] : prev[key] }), {});
-      return nextState;
-    });
+  const toggleSection = (sectionKey) => {
+    setOpenSections((prev) => ({
+      ...prev,
+      [sectionKey]: !prev[sectionKey]
+    }));
   };
 
-  const isSectionExpanded = (sectionKey) => !isMobile || !!mobileOpenSections[sectionKey];
+  const isSectionVisible = (sectionKey) => !isMobile || !!openSections[sectionKey];
 
-  const openSectionAndScroll = (sectionKey, targetId) => {
-    if (isMobile && !isSectionExpanded(sectionKey)) {
-      setMobileOpenSections((prev) => ({ ...prev, [sectionKey]: true }));
-      window.setTimeout(() => scrollToSection(targetId), 110);
-      return;
+  const openAndScrollToSection = (sectionKey, targetId) => {
+    if (isMobile) {
+      setOpenSections((prev) => ({
+        ...prev,
+        [sectionKey]: true
+      }));
+      window.setTimeout(() => scrollToSection(targetId), 80);
+    } else {
+      scrollToSection(targetId);
     }
-    scrollToSection(targetId);
   };
 
   useEffect(() => {
@@ -203,7 +204,7 @@ const ProductsAndServices = () => {
               <Button as={Link} to={quoteLink()} className="btn-round secondary-bg-color services-hero-primary-cta">
                 {t('products_and_services.revamp.hero.primaryCta')}
               </Button>
-              <Button variant="outline-secondary" className="btn-round services-hero-secondary-cta" onClick={() => jumpToSection('services')}>
+              <Button variant="outline-secondary" className="btn-round services-hero-secondary-cta" onClick={() => scrollToSection('services')}>
                 {t('products_and_services.revamp.hero.secondaryCta')}
               </Button>
             </div>
@@ -217,7 +218,7 @@ const ProductsAndServices = () => {
                 className={`services-category-chip ${activeCategory === item.key ? 'is-active' : ''}`}
                 onClick={() => {
                   setActiveCategory(item.key);
-                  openSectionAndScroll(item.key, item.target);
+                  openAndScrollToSection(item.key, item.target);
                 }}
               >
                 {t(`products_and_services.revamp.categoryNav.${item.key}`)}
@@ -237,19 +238,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('core')}
-                aria-controls="core-services-content"
-                onClick={() => handleSectionToggle('core')}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('core')}
+                aria-controls="services-section-core"
+                onClick={() => toggleSection('core')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.core.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.core.count })}</small>
                 </span>
-                <span>{isSectionExpanded('core') ? '−' : '+'}</span>
+                <span>{isSectionVisible('core') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="core-services-content" className={`services-collapsible-content ${isSectionExpanded('core') ? 'is-open' : ''}`}>
+            <div id="services-section-core" hidden={isMobile && !openSections.core} className="services-collapsible-content">
               <Row className="g-3">
                 {Object.entries(coreItems).map(([key, service]) => (
                   <Col xs={12} md={6} lg={4} key={key} id={key === 'residentialRegular' ? 'residential' : key === 'commercialRegular' ? 'commercial' : key === 'carpetCleaning' ? 'carpet' : undefined}>
@@ -287,19 +288,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('packages')}
-                aria-controls="packages-content"
-                onClick={() => handleSectionToggle('packages')}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('packages')}
+                aria-controls="services-section-packages"
+                onClick={() => toggleSection('packages')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.packages.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.packages.count })}</small>
                 </span>
-                <span>{isSectionExpanded('packages') ? '−' : '+'}</span>
+                <span>{isSectionVisible('packages') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="packages-content" className={`services-collapsible-content ${isSectionExpanded('packages') ? 'is-open' : ''}`}>
+            <div id="services-section-packages" hidden={isMobile && !openSections.packages} className="services-collapsible-content">
               <p className="text-muted mb-3">{t('products_and_services.revamp.packages.description')}</p>
               <p className="services-subtle-note">{t('products_and_services.revamp.packages.customizedNote')}</p>
               <Row className="g-3">
@@ -329,19 +330,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('addons')}
-                aria-controls="addons-content"
-                onClick={() => handleSectionToggle('addons')}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('addons')}
+                aria-controls="services-section-addons"
+                onClick={() => toggleSection('addons')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.addons.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.addons.count })}</small>
                 </span>
-                <span>{isSectionExpanded('addons') ? '−' : '+'}</span>
+                <span>{isSectionVisible('addons') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="addons-content" className={`services-collapsible-content ${isSectionExpanded('addons') ? 'is-open' : ''}`}>
+            <div id="services-section-addons" hidden={isMobile && !openSections.addons} className="services-collapsible-content">
               <p className="text-muted mb-3">{t('products_and_services.revamp.addons.description')}</p>
               <Row className="g-3">
                 {Object.values(addonGroups).map((group) => (
@@ -370,19 +371,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('carpetUpholstery')}
-                aria-controls="carpet-upholstery-content"
-                onClick={() => handleSectionToggle('carpetUpholstery')}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('carpetUpholstery')}
+                aria-controls="services-section-carpet-upholstery"
+                onClick={() => toggleSection('carpetUpholstery')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.carpetUpholstery.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.carpetUpholstery.count })}</small>
                 </span>
-                <span>{isSectionExpanded('carpetUpholstery') ? '−' : '+'}</span>
+                <span>{isSectionVisible('carpetUpholstery') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="carpet-upholstery-content" className={`services-collapsible-content ${isSectionExpanded('carpetUpholstery') ? 'is-open' : ''}`}>
+            <div id="services-section-carpet-upholstery" hidden={isMobile && !openSections.carpetUpholstery} className="services-collapsible-content">
               <p className="text-muted mb-3">{t('products_and_services.revamp.carpetUpholstery.description')}</p>
               <Row className="g-3">
                 {Object.entries(carpetColumns).map(([key, column]) => (
@@ -420,19 +421,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('specialty')}
-                aria-controls="specialty-content"
-                onClick={() => handleSectionToggle('specialty')}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('specialty')}
+                aria-controls="services-section-specialty"
+                onClick={() => toggleSection('specialty')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.specialty.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.specialty.count })}</small>
                 </span>
-                <span>{isSectionExpanded('specialty') ? '−' : '+'}</span>
+                <span>{isSectionVisible('specialty') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="specialty-content" className={`services-collapsible-content ${isSectionExpanded('specialty') ? 'is-open' : ''}`}>
+            <div id="services-section-specialty" hidden={isMobile && !openSections.specialty} className="services-collapsible-content">
               <Row className="g-3">
                 {Object.entries(specialtyItems).map(([key, item]) => (
                   <Col xs={12} md={4} key={key}>
@@ -469,19 +470,19 @@ const ProductsAndServices = () => {
             {isMobile ? (
               <button
                 type="button"
-                className="services-mobile-toggle"
-                aria-expanded={isSectionExpanded('howItWorks')}
-                aria-controls="how-it-works-content"
-                onClick={() => setMobileOpenSections((prev) => ({ ...prev, howItWorks: !prev.howItWorks }))}
+                className="services-mobile-section-toggle"
+                aria-expanded={isSectionVisible('howItWorks')}
+                aria-controls="services-section-how-it-works"
+                onClick={() => toggleSection('howItWorks')}
               >
                 <span className="services-mobile-toggle-copy">
                   <span>{sectionMeta.howItWorks.summary}</span>
                   <small>{t('products_and_services.revamp.mobileSummaryCount', { count: sectionMeta.howItWorks.count })}</small>
                 </span>
-                <span>{isSectionExpanded('howItWorks') ? '−' : '+'}</span>
+                <span>{isSectionVisible('howItWorks') ? '−' : '+'}</span>
               </button>
             ) : null}
-            <div id="how-it-works-content" className={`services-collapsible-content ${isSectionExpanded('howItWorks') ? 'is-open' : ''}`}>
+            <div id="services-section-how-it-works" hidden={isMobile && !openSections.howItWorks} className="services-collapsible-content">
               <Row className="g-2 g-md-3">
                 {howItWorksItems.map((step, index) => (
                   <Col xs={6} md={6} lg={3} key={step.title}>

--- a/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
+++ b/client/src/components/Pages/Navigation/ServiceLandingPage.jsx
@@ -7,30 +7,130 @@ const SERVICE_CONTENT = {
     intro:
       "Keep your home consistently clean with recurring or one-time residential cleaning delivered by the CleanAR Solutions team.",
     query: "Residential+Cleaning",
+    bestFor: "Busy households that want reliable weekly, biweekly, or monthly support.",
+    included: [
+      "Kitchen, bathroom, and common area maintenance",
+      "Dusting, vacuuming, and floor care",
+      "Flexible recurring schedules"
+    ],
+    addOns: ["Interior windows", "Bed linen service", "Laundry service"]
+  },
+  "deep-cleaning": {
+    title: "Deep Cleaning Services",
+    intro:
+      "Get a detailed top-to-bottom reset for homes or units that need more than standard recurring maintenance.",
+    query: "Deep+Cleaning",
+    bestFor: "Seasonal cleaning, first-time service, or post-renovation touch-ups.",
+    included: [
+      "Detailed kitchen and bathroom focus",
+      "Baseboards, edges, and high-touch surfaces",
+      "Targeted grime and buildup removal"
+    ],
+    addOns: ["Fridge deep cleaning", "Oven deep cleaning", "Organization & styling"]
+  },
+  "move-in-move-out-cleaning": {
+    title: "Move-In / Move-Out Cleaning",
+    intro:
+      "Prepare empty units for handover, showings, or move-in day with a thorough professional clean.",
+    query: "Move+In+Move+Out+Cleaning",
+    bestFor: "Tenants, landlords, realtors, and property managers.",
+    included: [
+      "Cabinet, appliance exterior, and surface wipe-downs",
+      "Bathroom sanitization and fixture polishing",
+      "Floor vacuuming, mopping, and finishing"
+    ],
+    addOns: ["Interior windows", "Balcony deep cleaning", "Curtain steam cleaning"]
   },
   "commercial-cleaning": {
     title: "Commercial Cleaning Services",
     intro:
       "Maintain a healthier, more professional workplace with customized commercial cleaning services for offices and facilities.",
     query: "Commercial+Cleaning",
+    bestFor: "Offices, retail spaces, and shared commercial environments.",
+    included: [
+      "Reception, workspace, and washroom cleaning",
+      "High-touch disinfection and waste handling",
+      "Flexible day/evening scheduling"
+    ],
+    addOns: ["Carpet extraction", "Window interior cleaning", "Amenities maintenance"]
   },
-  "window-cleaning": {
-    title: "Window Cleaning Services",
+  "commercial-deep-cleaning": {
+    title: "Commercial Deep Cleaning",
     intro:
-      "Improve curb appeal and indoor light with interior and exterior window cleaning for homes and businesses.",
-    query: "Window+Cleaning",
+      "Reset high-traffic business spaces with detailed sanitation and deeper cleaning workflows.",
+    query: "Commercial+Cleaning",
+    bestFor: "Quarterly resets, occupancy transitions, and heavily used facilities.",
+    included: [
+      "Detail-focused sanitation and spot treatment",
+      "Deep cleaning for shared areas and washrooms",
+      "Targeted service plan based on traffic patterns"
+    ],
+    addOns: ["Carpet cleaning", "Upholstery cleaning", "Monthly building cleaning"]
   },
-  "carpet-and-upholstery-cleaning": {
-    title: "Carpet and Upholstery Cleaning Services",
+  "carpet-cleaning": {
+    title: "Carpet Cleaning Services",
     intro:
-      "Refresh carpets and soft surfaces with deep cleaning solutions that remove built-up soil, odors, and stains.",
+      "Steam and extraction cleaning to refresh carpets, reduce odours, and lift embedded dirt.",
     query: "Carpet+And+Upholstery",
+    bestFor: "Small rooms, high-traffic spaces, and common-area carpet maintenance.",
+    included: [
+      "Hot-water extraction process",
+      "Spot treatment for common stains",
+      "Tailored approach based on fiber and condition"
+    ],
+    addOns: ["Hallways/common areas", "Upholstery pairing", "Post-service deodorizing"]
   },
-  "power-pressure-washing": {
-    title: "Power and Pressure Washing Services",
+  "upholstery-cleaning": {
+    title: "Upholstery Cleaning Services",
     intro:
-      "Restore outdoor surfaces with targeted pressure washing for walkways, entries, and exterior areas.",
-    query: "Power/Pressure+Washing",
+      "Deep-clean sofas, loveseats, chairs, and fabric seating with methods matched to material and condition.",
+    query: "Carpet+And+Upholstery",
+    bestFor: "Furniture refreshes, stain treatment, and allergy-conscious maintenance.",
+    included: [
+      "Material-safe upholstery cleaning methods",
+      "Odour and stain reduction support",
+      "Options for individual items or full sets"
+    ],
+    addOns: ["Dining chair sets", "Curtain steam cleaning", "Carpet bundle quote"]
+  },
+  "post-construction-cleaning": {
+    title: "Post-Construction Cleaning",
+    intro:
+      "Clear fine dust, debris, and construction residue so your renovated space is move-in ready.",
+    query: "Post-Construction+Cleaning",
+    bestFor: "Renovated units, office fit-outs, and newly finished interiors.",
+    included: [
+      "Detailed dust and surface removal",
+      "Fixture, trim, and edge cleaning",
+      "Final handover-ready finishing"
+    ],
+    addOns: ["Window interior cleaning", "Floor detailing", "Full unit clean-out"]
+  },
+  "full-unit-clean-out": {
+    title: "Full Unit Clean-Out",
+    intro:
+      "Comprehensive reset cleaning for units that require a full interior turnaround.",
+    query: "Deep+Cleaning",
+    bestFor: "Heavily used spaces, transitions, or intensive reset projects.",
+    included: [
+      "Whole-unit interior cleaning and reset",
+      "Targeted high-build-up area treatment",
+      "Scope aligned to access and condition"
+    ],
+    addOns: ["Bathroom recaulk prep cleanup", "Balcony deep cleaning", "Laundry service"]
+  },
+  "monthly-building-amenities-cleaning": {
+    title: "Monthly Building / Amenities Cleaning",
+    intro:
+      "Recurring cleaning plans for lobbies, shared amenities, and resident-facing common areas.",
+    query: "Commercial+Cleaning",
+    bestFor: "Property managers and building teams needing predictable quality standards.",
+    included: [
+      "Amenity and shared-space cleaning routines",
+      "Monthly cadence with flexible service windows",
+      "Checklist-based consistency and reporting readiness"
+    ],
+    addOns: ["Carpet extraction", "Glass cleaning", "Seasonal deep clean support"]
   },
 };
 
@@ -46,8 +146,27 @@ const ServiceLandingPage = () => {
     <section className="container py-5 mt-5">
       <h1 className="primary-color text-bold mb-3">{service.title}</h1>
       <p className="lead text-cleanar-color mb-4">{service.intro}</p>
+      {service.bestFor ? (
+        <p className="mb-4 text-cleanar-color"><strong>Best for:</strong> {service.bestFor}</p>
+      ) : null}
+      {Array.isArray(service.included) && service.included.length > 0 ? (
+        <div className="mb-4">
+          <h2 className="h5 text-cleanar-color text-bold mb-2">What’s included</h2>
+          <ul className="mb-0">
+            {service.included.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        </div>
+      ) : null}
+      {Array.isArray(service.addOns) && service.addOns.length > 0 ? (
+        <div className="mb-4">
+          <h2 className="h5 text-cleanar-color text-bold mb-2">Optional add-ons</h2>
+          <ul className="mb-0">
+            {service.addOns.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        </div>
+      ) : null}
       <div className="d-flex flex-wrap gap-2">
-        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/?service=${service.query}`}>
+        <Link className="btn btn-primary btn-round secondary-bg-color" to={`/?service=${service.query}&scrollToQuote=true`}>
           Request a Quote
         </Link>
         <Link className="btn btn-outline-secondary btn-round" to="/products-and-services">

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -584,7 +584,190 @@
       "Transform curb appeal with thorough cleaning of driveways, sidewalks, patios, decks, and home exterior surfaces.",
       "Parking lots, building exteriors, loading docks, and storefront cleaning to maintain professional appearance and safety standards."
     ],
-    "power_pressure_washing_button": "Get Quote for Power Washing"
+    "power_pressure_washing_button": "Get Quote for Power Washing",
+    "revamp": {
+      "hero": {
+        "title": "Professional Cleaning Services in Toronto & the GTA",
+        "subtitle": "From regular home cleaning to commercial deep cleans, carpet extraction, upholstery care, and move-in/move-out services, CleanAR Solutions delivers reliable cleaning tailored to your space.",
+        "primaryCta": "Request a Quote",
+        "secondaryCta": "View Services",
+        "trustLabel": "Service trust highlights",
+        "trustChips": [
+          "Residential & Commercial",
+          "Toronto & GTA",
+          "Flexible Scheduling",
+          "Eco-conscious Options"
+        ]
+      },
+      "categoryNav": {
+        "ariaLabel": "Service category navigation",
+        "core": "Core Services",
+        "packages": "Packages",
+        "addons": "Add-ons",
+        "carpetUpholstery": "Carpet & Upholstery",
+        "specialty": "Specialty"
+      },
+      "core": {
+        "title": "Core Services",
+        "bestForLabel": "Best for:",
+        "cta": "Request this service",
+        "items": {
+          "residentialRegular": {
+            "name": "Residential Regular Cleaning",
+            "description": "Routine cleaning for weekly, biweekly, or monthly maintenance.",
+            "bestFor": "Busy households that want a consistently clean home."
+          },
+          "residentialDeep": {
+            "name": "Residential Deep Cleaning",
+            "description": "Detailed cleaning for first-time, seasonal, or catch-up service.",
+            "bestFor": "Homes that need extra detail beyond regular maintenance."
+          },
+          "moveInOut": {
+            "name": "Move-In / Move-Out Cleaning",
+            "description": "Empty-unit cleaning to prepare a space for new occupants.",
+            "bestFor": "Tenants, homeowners, and landlords preparing for turnover."
+          },
+          "commercialRegular": {
+            "name": "Commercial Cleaning Service",
+            "description": "Recurring cleaning for offices, retail spaces, and businesses.",
+            "bestFor": "Teams that need dependable cleaning with flexible scheduling."
+          },
+          "commercialDeep": {
+            "name": "Commercial Deep Cleaning",
+            "description": "Detailed sanitation and high-traffic area cleaning for commercial spaces.",
+            "bestFor": "Facilities needing periodic reset cleans and stronger sanitization."
+          },
+          "carpetCleaning": {
+            "name": "Carpet Cleaning (Steam / Extraction)",
+            "description": "Steam/hot water extraction to refresh carpets and remove dirt, stains, and odours.",
+            "bestFor": "High-traffic areas, rentals, and homes with pets or kids."
+          },
+          "upholsteryCleaning": {
+            "name": "Upholstery Cleaning",
+            "description": "Deep cleaning for sofas, chairs, and upholstered furniture.",
+            "bestFor": "Furniture that needs a fresh reset and stain treatment."
+          }
+        }
+      },
+      "packages": {
+        "title": "Cleaning Packages",
+        "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "items": [
+          {
+            "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Tailored by layout, current condition, and requested frequency."
+          },
+          {
+            "name": "Condo Cleaning Package (2 Bed / 2 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Ideal for recurring maintenance or first-time reset cleanings."
+          },
+          {
+            "name": "House Cleaning Package (3+ Bedrooms)",
+            "pricing": "Starting from custom quote",
+            "note": "Scope can be expanded with deep-clean and specialty add-ons."
+          }
+        ]
+      },
+      "addons": {
+        "title": "Add-ons",
+        "description": "Enhance your cleaning with optional add-ons.",
+        "groups": {
+          "kitchen": {
+            "title": "Kitchen",
+            "items": [
+              "Fridge Deep Cleaning",
+              "Oven Deep Cleaning",
+              "Dishwasher Deep Cleaning",
+              "Microwave Cleaning",
+              "Kitchen Cabinets Cleaning"
+            ]
+          },
+          "bathroom": {
+            "title": "Bathroom",
+            "items": [
+              "Bathroom Deep Cleaning",
+              "Bathroom Recaulking"
+            ]
+          },
+          "general": {
+            "title": "General",
+            "items": [
+              "Interior Window Cleaning",
+              "Bed Linen Service",
+              "Laundry Service",
+              "Organization & Styling"
+            ]
+          },
+          "exteriorSpecialty": {
+            "title": "Exterior / Specialty",
+            "items": [
+              "Balcony Deep Cleaning",
+              "Deck Cleaning",
+              "Curtain Steam Cleaning"
+            ]
+          }
+        }
+      },
+      "carpetUpholstery": {
+        "title": "Carpet & Upholstery",
+        "description": "Pricing depends on size, material, condition, stains, and access.",
+        "columns": {
+          "carpet": {
+            "title": "Carpet Cleaning",
+            "items": [
+              "Carpet Cleaning – Small Room",
+              "Carpet Cleaning – Medium Room",
+              "Carpet Cleaning – Large Area",
+              "Carpet Cleaning – Hallways/Common Areas"
+            ]
+          },
+          "upholstery": {
+            "title": "Upholstery Cleaning",
+            "items": [
+              "Upholstery Cleaning – Sofa",
+              "Upholstery Cleaning – Loveseat",
+              "Upholstery Cleaning – Armchair",
+              "Upholstery Cleaning – Dining Chair",
+              "Upholstery Cleaning – Full Set"
+            ]
+          }
+        }
+      },
+      "specialty": {
+        "title": "Specialty Services",
+        "cta": "Request this service",
+        "items": {
+          "postConstruction": {
+            "name": "Post-Construction Cleaning",
+            "description": "Detailed removal of fine dust, debris, and residue so the space is ready for use."
+          },
+          "fullUnitCleanOut": {
+            "name": "Full Unit Clean-Out",
+            "description": "Comprehensive interior clean-out support for turnovers, transitions, and heavy-reset projects."
+          },
+          "monthlyBuilding": {
+            "name": "Monthly Building / Amenities Cleaning",
+            "description": "Planned recurring cleaning for lobbies, shared spaces, and amenity areas."
+          }
+        }
+      },
+      "howItWorks": {
+        "title": "How it works",
+        "steps": [
+          "Tell us about your space",
+          "We recommend the right service",
+          "Receive a clear quote",
+          "Enjoy a fresh, professionally cleaned space"
+        ]
+      },
+      "finalCta": {
+        "title": "Not sure which service you need?",
+        "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "button": "Request a Quote"
+      }
+    }
   },
   "about": {
     "welcome_heading": "Welcome to CleanAR Solutions",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -607,6 +607,8 @@
         "carpetUpholstery": "Carpet & Upholstery",
         "specialty": "Specialty"
       },
+      "backToTop": "Back to top",
+      "learnMore": "Learn more",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -652,6 +652,7 @@
       "packages": {
         "title": "Cleaning Packages",
         "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "customizedNote": "Customized based on size, condition, and frequency.",
         "items": [
           {
             "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
@@ -760,11 +761,18 @@
           "We recommend the right service",
           "Receive a clear quote",
           "Enjoy a fresh, professionally cleaned space"
+        ],
+        "stepDescriptions": [
+          "Share your home or business details, timing, and goals.",
+          "Our team matches your needs to the right service mix.",
+          "You get a transparent quote with scope and timing.",
+          "Our professionals deliver a reliable, high-quality clean."
         ]
       },
       "finalCta": {
         "title": "Not sure which service you need?",
         "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "supportText": "We’ll recommend the best option based on your space, schedule, and budget.",
         "button": "Request a Quote"
       }
     }

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -609,6 +609,13 @@
       },
       "backToTop": "Back to top",
       "learnMore": "Learn more",
+      "mobileSummaries": {
+        "core": "{{count}} core services available",
+        "packages": "{{count}} package options available",
+        "addons": "{{count}} add-on options available",
+        "carpetUpholstery": "{{count}} carpet & upholstery options",
+        "specialty": "{{count}} specialty services available"
+      },
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -616,6 +616,15 @@
         "carpetUpholstery": "{{count}} carpet & upholstery options",
         "specialty": "{{count}} specialty services available"
       },
+      "mobileSectionDescriptions": {
+        "core": "Main cleaning services for homes, businesses, carpets, and upholstery.",
+        "packages": "Simple starting points for condos and homes.",
+        "addons": "Optional upgrades for kitchens, bathrooms, windows, laundry, and more.",
+        "carpetUpholstery": "Room, carpet, sofa, chair, and furniture cleaning options.",
+        "specialty": "Higher-scope projects for construction, clean-outs, and buildings.",
+        "howItWorks": "A simple quote process from details to service."
+      },
+      "mobileSummaryCount": "{{count}} options",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -597,6 +597,13 @@
       },
       "backToTop": "Back to top",
       "learnMore": "Learn more",
+      "mobileSummaries": {
+        "core": "{{count}} core services available",
+        "packages": "{{count}} package options available",
+        "addons": "{{count}} add-on options available",
+        "carpetUpholstery": "{{count}} carpet & upholstery options",
+        "specialty": "{{count}} specialty services available"
+      },
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -595,6 +595,8 @@
         "carpetUpholstery": "Carpet & Upholstery",
         "specialty": "Specialty"
       },
+      "backToTop": "Back to top",
+      "learnMore": "Learn more",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -604,6 +604,15 @@
         "carpetUpholstery": "{{count}} carpet & upholstery options",
         "specialty": "{{count}} specialty services available"
       },
+      "mobileSectionDescriptions": {
+        "core": "Main cleaning services for homes, businesses, carpets, and upholstery.",
+        "packages": "Simple starting points for condos and homes.",
+        "addons": "Optional upgrades for kitchens, bathrooms, windows, laundry, and more.",
+        "carpetUpholstery": "Room, carpet, sofa, chair, and furniture cleaning options.",
+        "specialty": "Higher-scope projects for construction, clean-outs, and buildings.",
+        "howItWorks": "A simple quote process from details to service."
+      },
+      "mobileSummaryCount": "{{count}} options",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -640,6 +640,7 @@
       "packages": {
         "title": "Cleaning Packages",
         "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "customizedNote": "Customized based on size, condition, and frequency.",
         "items": [
           {
             "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
@@ -748,11 +749,18 @@
           "We recommend the right service",
           "Receive a clear quote",
           "Enjoy a fresh, professionally cleaned space"
+        ],
+        "stepDescriptions": [
+          "Share your home or business details, timing, and goals.",
+          "Our team matches your needs to the right service mix.",
+          "You get a transparent quote with scope and timing.",
+          "Our professionals deliver a reliable, high-quality clean."
         ]
       },
       "finalCta": {
         "title": "Not sure which service you need?",
         "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "supportText": "We’ll recommend the best option based on your space, schedule, and budget.",
         "button": "Request a Quote"
       }
     }

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -572,7 +572,190 @@
       "Transforma el atractivo de su hogar con una limpieza a fondo de entradas, aceras, patios, terrazas y superficies exteriores.",
       "Limpieza de estacionamientos, fachadas de edificios, muelles de carga y vitrinas para mantener una apariencia profesional y estándares de seguridad."
     ],
-    "power_pressure_washing_button": "Cotizar limpieza a presión"
+    "power_pressure_washing_button": "Cotizar limpieza a presión",
+    "revamp": {
+      "hero": {
+        "title": "Professional Cleaning Services in Toronto & the GTA",
+        "subtitle": "From regular home cleaning to commercial deep cleans, carpet extraction, upholstery care, and move-in/move-out services, CleanAR Solutions delivers reliable cleaning tailored to your space.",
+        "primaryCta": "Request a Quote",
+        "secondaryCta": "View Services",
+        "trustLabel": "Service trust highlights",
+        "trustChips": [
+          "Residential & Commercial",
+          "Toronto & GTA",
+          "Flexible Scheduling",
+          "Eco-conscious Options"
+        ]
+      },
+      "categoryNav": {
+        "ariaLabel": "Service category navigation",
+        "core": "Core Services",
+        "packages": "Packages",
+        "addons": "Add-ons",
+        "carpetUpholstery": "Carpet & Upholstery",
+        "specialty": "Specialty"
+      },
+      "core": {
+        "title": "Core Services",
+        "bestForLabel": "Best for:",
+        "cta": "Request this service",
+        "items": {
+          "residentialRegular": {
+            "name": "Residential Regular Cleaning",
+            "description": "Routine cleaning for weekly, biweekly, or monthly maintenance.",
+            "bestFor": "Busy households that want a consistently clean home."
+          },
+          "residentialDeep": {
+            "name": "Residential Deep Cleaning",
+            "description": "Detailed cleaning for first-time, seasonal, or catch-up service.",
+            "bestFor": "Homes that need extra detail beyond regular maintenance."
+          },
+          "moveInOut": {
+            "name": "Move-In / Move-Out Cleaning",
+            "description": "Empty-unit cleaning to prepare a space for new occupants.",
+            "bestFor": "Tenants, homeowners, and landlords preparing for turnover."
+          },
+          "commercialRegular": {
+            "name": "Commercial Cleaning Service",
+            "description": "Recurring cleaning for offices, retail spaces, and businesses.",
+            "bestFor": "Teams that need dependable cleaning with flexible scheduling."
+          },
+          "commercialDeep": {
+            "name": "Commercial Deep Cleaning",
+            "description": "Detailed sanitation and high-traffic area cleaning for commercial spaces.",
+            "bestFor": "Facilities needing periodic reset cleans and stronger sanitization."
+          },
+          "carpetCleaning": {
+            "name": "Carpet Cleaning (Steam / Extraction)",
+            "description": "Steam/hot water extraction to refresh carpets and remove dirt, stains, and odours.",
+            "bestFor": "High-traffic areas, rentals, and homes with pets or kids."
+          },
+          "upholsteryCleaning": {
+            "name": "Upholstery Cleaning",
+            "description": "Deep cleaning for sofas, chairs, and upholstered furniture.",
+            "bestFor": "Furniture that needs a fresh reset and stain treatment."
+          }
+        }
+      },
+      "packages": {
+        "title": "Cleaning Packages",
+        "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "items": [
+          {
+            "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Tailored by layout, current condition, and requested frequency."
+          },
+          {
+            "name": "Condo Cleaning Package (2 Bed / 2 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Ideal for recurring maintenance or first-time reset cleanings."
+          },
+          {
+            "name": "House Cleaning Package (3+ Bedrooms)",
+            "pricing": "Starting from custom quote",
+            "note": "Scope can be expanded with deep-clean and specialty add-ons."
+          }
+        ]
+      },
+      "addons": {
+        "title": "Add-ons",
+        "description": "Enhance your cleaning with optional add-ons.",
+        "groups": {
+          "kitchen": {
+            "title": "Kitchen",
+            "items": [
+              "Fridge Deep Cleaning",
+              "Oven Deep Cleaning",
+              "Dishwasher Deep Cleaning",
+              "Microwave Cleaning",
+              "Kitchen Cabinets Cleaning"
+            ]
+          },
+          "bathroom": {
+            "title": "Bathroom",
+            "items": [
+              "Bathroom Deep Cleaning",
+              "Bathroom Recaulking"
+            ]
+          },
+          "general": {
+            "title": "General",
+            "items": [
+              "Interior Window Cleaning",
+              "Bed Linen Service",
+              "Laundry Service",
+              "Organization & Styling"
+            ]
+          },
+          "exteriorSpecialty": {
+            "title": "Exterior / Specialty",
+            "items": [
+              "Balcony Deep Cleaning",
+              "Deck Cleaning",
+              "Curtain Steam Cleaning"
+            ]
+          }
+        }
+      },
+      "carpetUpholstery": {
+        "title": "Carpet & Upholstery",
+        "description": "Pricing depends on size, material, condition, stains, and access.",
+        "columns": {
+          "carpet": {
+            "title": "Carpet Cleaning",
+            "items": [
+              "Carpet Cleaning – Small Room",
+              "Carpet Cleaning – Medium Room",
+              "Carpet Cleaning – Large Area",
+              "Carpet Cleaning – Hallways/Common Areas"
+            ]
+          },
+          "upholstery": {
+            "title": "Upholstery Cleaning",
+            "items": [
+              "Upholstery Cleaning – Sofa",
+              "Upholstery Cleaning – Loveseat",
+              "Upholstery Cleaning – Armchair",
+              "Upholstery Cleaning – Dining Chair",
+              "Upholstery Cleaning – Full Set"
+            ]
+          }
+        }
+      },
+      "specialty": {
+        "title": "Specialty Services",
+        "cta": "Request this service",
+        "items": {
+          "postConstruction": {
+            "name": "Post-Construction Cleaning",
+            "description": "Detailed removal of fine dust, debris, and residue so the space is ready for use."
+          },
+          "fullUnitCleanOut": {
+            "name": "Full Unit Clean-Out",
+            "description": "Comprehensive interior clean-out support for turnovers, transitions, and heavy-reset projects."
+          },
+          "monthlyBuilding": {
+            "name": "Monthly Building / Amenities Cleaning",
+            "description": "Planned recurring cleaning for lobbies, shared spaces, and amenity areas."
+          }
+        }
+      },
+      "howItWorks": {
+        "title": "How it works",
+        "steps": [
+          "Tell us about your space",
+          "We recommend the right service",
+          "Receive a clear quote",
+          "Enjoy a fresh, professionally cleaned space"
+        ]
+      },
+      "finalCta": {
+        "title": "Not sure which service you need?",
+        "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "button": "Request a Quote"
+      }
+    }
   },
   "about": {
     "welcome_heading": "Bienvenido a CleanAR Solutions",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -571,7 +571,190 @@
       "Transformez l'attrait de votre maison avec un nettoyage approfondi des allées, des trottoirs, des patios, des terrasses et des surfaces extérieures.",
       "Nettoyage des parkings, des façades de bâtiments, des quais de chargement et des vitrines pour maintenir une apparence professionnelle et des normes de sécurité."
     ],
-    "power_pressure_washing_button": "Ajouter le nettoyage haute pression au devis"
+    "power_pressure_washing_button": "Ajouter le nettoyage haute pression au devis",
+    "revamp": {
+      "hero": {
+        "title": "Professional Cleaning Services in Toronto & the GTA",
+        "subtitle": "From regular home cleaning to commercial deep cleans, carpet extraction, upholstery care, and move-in/move-out services, CleanAR Solutions delivers reliable cleaning tailored to your space.",
+        "primaryCta": "Request a Quote",
+        "secondaryCta": "View Services",
+        "trustLabel": "Service trust highlights",
+        "trustChips": [
+          "Residential & Commercial",
+          "Toronto & GTA",
+          "Flexible Scheduling",
+          "Eco-conscious Options"
+        ]
+      },
+      "categoryNav": {
+        "ariaLabel": "Service category navigation",
+        "core": "Core Services",
+        "packages": "Packages",
+        "addons": "Add-ons",
+        "carpetUpholstery": "Carpet & Upholstery",
+        "specialty": "Specialty"
+      },
+      "core": {
+        "title": "Core Services",
+        "bestForLabel": "Best for:",
+        "cta": "Request this service",
+        "items": {
+          "residentialRegular": {
+            "name": "Residential Regular Cleaning",
+            "description": "Routine cleaning for weekly, biweekly, or monthly maintenance.",
+            "bestFor": "Busy households that want a consistently clean home."
+          },
+          "residentialDeep": {
+            "name": "Residential Deep Cleaning",
+            "description": "Detailed cleaning for first-time, seasonal, or catch-up service.",
+            "bestFor": "Homes that need extra detail beyond regular maintenance."
+          },
+          "moveInOut": {
+            "name": "Move-In / Move-Out Cleaning",
+            "description": "Empty-unit cleaning to prepare a space for new occupants.",
+            "bestFor": "Tenants, homeowners, and landlords preparing for turnover."
+          },
+          "commercialRegular": {
+            "name": "Commercial Cleaning Service",
+            "description": "Recurring cleaning for offices, retail spaces, and businesses.",
+            "bestFor": "Teams that need dependable cleaning with flexible scheduling."
+          },
+          "commercialDeep": {
+            "name": "Commercial Deep Cleaning",
+            "description": "Detailed sanitation and high-traffic area cleaning for commercial spaces.",
+            "bestFor": "Facilities needing periodic reset cleans and stronger sanitization."
+          },
+          "carpetCleaning": {
+            "name": "Carpet Cleaning (Steam / Extraction)",
+            "description": "Steam/hot water extraction to refresh carpets and remove dirt, stains, and odours.",
+            "bestFor": "High-traffic areas, rentals, and homes with pets or kids."
+          },
+          "upholsteryCleaning": {
+            "name": "Upholstery Cleaning",
+            "description": "Deep cleaning for sofas, chairs, and upholstered furniture.",
+            "bestFor": "Furniture that needs a fresh reset and stain treatment."
+          }
+        }
+      },
+      "packages": {
+        "title": "Cleaning Packages",
+        "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "items": [
+          {
+            "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Tailored by layout, current condition, and requested frequency."
+          },
+          {
+            "name": "Condo Cleaning Package (2 Bed / 2 Bath)",
+            "pricing": "Starting from custom quote",
+            "note": "Ideal for recurring maintenance or first-time reset cleanings."
+          },
+          {
+            "name": "House Cleaning Package (3+ Bedrooms)",
+            "pricing": "Starting from custom quote",
+            "note": "Scope can be expanded with deep-clean and specialty add-ons."
+          }
+        ]
+      },
+      "addons": {
+        "title": "Add-ons",
+        "description": "Enhance your cleaning with optional add-ons.",
+        "groups": {
+          "kitchen": {
+            "title": "Kitchen",
+            "items": [
+              "Fridge Deep Cleaning",
+              "Oven Deep Cleaning",
+              "Dishwasher Deep Cleaning",
+              "Microwave Cleaning",
+              "Kitchen Cabinets Cleaning"
+            ]
+          },
+          "bathroom": {
+            "title": "Bathroom",
+            "items": [
+              "Bathroom Deep Cleaning",
+              "Bathroom Recaulking"
+            ]
+          },
+          "general": {
+            "title": "General",
+            "items": [
+              "Interior Window Cleaning",
+              "Bed Linen Service",
+              "Laundry Service",
+              "Organization & Styling"
+            ]
+          },
+          "exteriorSpecialty": {
+            "title": "Exterior / Specialty",
+            "items": [
+              "Balcony Deep Cleaning",
+              "Deck Cleaning",
+              "Curtain Steam Cleaning"
+            ]
+          }
+        }
+      },
+      "carpetUpholstery": {
+        "title": "Carpet & Upholstery",
+        "description": "Pricing depends on size, material, condition, stains, and access.",
+        "columns": {
+          "carpet": {
+            "title": "Carpet Cleaning",
+            "items": [
+              "Carpet Cleaning – Small Room",
+              "Carpet Cleaning – Medium Room",
+              "Carpet Cleaning – Large Area",
+              "Carpet Cleaning – Hallways/Common Areas"
+            ]
+          },
+          "upholstery": {
+            "title": "Upholstery Cleaning",
+            "items": [
+              "Upholstery Cleaning – Sofa",
+              "Upholstery Cleaning – Loveseat",
+              "Upholstery Cleaning – Armchair",
+              "Upholstery Cleaning – Dining Chair",
+              "Upholstery Cleaning – Full Set"
+            ]
+          }
+        }
+      },
+      "specialty": {
+        "title": "Specialty Services",
+        "cta": "Request this service",
+        "items": {
+          "postConstruction": {
+            "name": "Post-Construction Cleaning",
+            "description": "Detailed removal of fine dust, debris, and residue so the space is ready for use."
+          },
+          "fullUnitCleanOut": {
+            "name": "Full Unit Clean-Out",
+            "description": "Comprehensive interior clean-out support for turnovers, transitions, and heavy-reset projects."
+          },
+          "monthlyBuilding": {
+            "name": "Monthly Building / Amenities Cleaning",
+            "description": "Planned recurring cleaning for lobbies, shared spaces, and amenity areas."
+          }
+        }
+      },
+      "howItWorks": {
+        "title": "How it works",
+        "steps": [
+          "Tell us about your space",
+          "We recommend the right service",
+          "Receive a clear quote",
+          "Enjoy a fresh, professionally cleaned space"
+        ]
+      },
+      "finalCta": {
+        "title": "Not sure which service you need?",
+        "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "button": "Request a Quote"
+      }
+    }
   },
   "about": {
     "welcome_heading": "Bienvenue chez CleanAR Solutions",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -596,6 +596,13 @@
       },
       "backToTop": "Back to top",
       "learnMore": "Learn more",
+      "mobileSummaries": {
+        "core": "{{count}} core services available",
+        "packages": "{{count}} package options available",
+        "addons": "{{count}} add-on options available",
+        "carpetUpholstery": "{{count}} carpet & upholstery options",
+        "specialty": "{{count}} specialty services available"
+      },
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -639,6 +639,7 @@
       "packages": {
         "title": "Cleaning Packages",
         "description": "Packages are customizable based on size, condition, frequency, and scope.",
+        "customizedNote": "Customized based on size, condition, and frequency.",
         "items": [
           {
             "name": "Condo Cleaning Package (1 Bed / 1 Bath)",
@@ -747,11 +748,18 @@
           "We recommend the right service",
           "Receive a clear quote",
           "Enjoy a fresh, professionally cleaned space"
+        ],
+        "stepDescriptions": [
+          "Share your home or business details, timing, and goals.",
+          "Our team matches your needs to the right service mix.",
+          "You get a transparent quote with scope and timing.",
+          "Our professionals deliver a reliable, high-quality clean."
         ]
       },
       "finalCta": {
         "title": "Not sure which service you need?",
         "description": "Send us a few details and we’ll recommend the best option for your space, schedule, and budget.",
+        "supportText": "We’ll recommend the best option based on your space, schedule, and budget.",
         "button": "Request a Quote"
       }
     }

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -603,6 +603,15 @@
         "carpetUpholstery": "{{count}} carpet & upholstery options",
         "specialty": "{{count}} specialty services available"
       },
+      "mobileSectionDescriptions": {
+        "core": "Main cleaning services for homes, businesses, carpets, and upholstery.",
+        "packages": "Simple starting points for condos and homes.",
+        "addons": "Optional upgrades for kitchens, bathrooms, windows, laundry, and more.",
+        "carpetUpholstery": "Room, carpet, sofa, chair, and furniture cleaning options.",
+        "specialty": "Higher-scope projects for construction, clean-outs, and buildings.",
+        "howItWorks": "A simple quote process from details to service."
+      },
+      "mobileSummaryCount": "{{count}} options",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -594,6 +594,8 @@
         "carpetUpholstery": "Carpet & Upholstery",
         "specialty": "Specialty"
       },
+      "backToTop": "Back to top",
+      "learnMore": "Learn more",
       "core": {
         "title": "Core Services",
         "bestForLabel": "Best for:",

--- a/client/src/seo/routeMeta.mjs
+++ b/client/src/seo/routeMeta.mjs
@@ -45,9 +45,9 @@ export const ROUTE_META = {
       "Learn about CleanAR Solutions, our mission, and our commitment to reliable, high-quality cleaning services across Toronto and the GTA.",
   },
   "/products-and-services": {
-    title: "Cleaning Services | Residential & Commercial | CleanAR Solutions",
+    title: "Cleaning Services in Toronto & GTA | CleanAR Solutions",
     description:
-      "Explore residential and commercial cleaning services from CleanAR Solutions in Toronto and the GTA.",
+      "Explore CleanAR Solutions’ residential, commercial, deep cleaning, move-in/move-out, carpet, upholstery, and specialty cleaning services across Toronto and the GTA.",
   },
   "/blog": {
     title: "CleanAR Blog | Cleaning Insights & Company Updates",

--- a/client/src/seo/routeMeta.mjs
+++ b/client/src/seo/routeMeta.mjs
@@ -64,10 +64,50 @@ export const ROUTE_META = {
     description:
       "Professional commercial cleaning for offices and facilities in Toronto and the GTA by CleanAR Solutions.",
   },
+  "/services/deep-cleaning": {
+    title: "Deep Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Book detailed deep cleaning services for homes and commercial spaces in Toronto and the GTA.",
+  },
+  "/services/move-in-move-out-cleaning": {
+    title: "Move-In / Move-Out Cleaning in Toronto | CleanAR Solutions",
+    description:
+      "Professional move-in and move-out cleaning in Toronto and the GTA for smooth property transitions.",
+  },
+  "/services/commercial-deep-cleaning": {
+    title: "Commercial Deep Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Targeted commercial deep cleaning for high-traffic facilities, offices, and shared spaces in Toronto and the GTA.",
+  },
   "/services/window-cleaning": {
     title: "Window Cleaning Services in Toronto | CleanAR Solutions",
     description:
       "Interior and exterior window cleaning services for homes and businesses across Toronto and the GTA.",
+  },
+  "/services/carpet-cleaning": {
+    title: "Carpet Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Steam and extraction carpet cleaning for homes and commercial spaces across Toronto and the GTA.",
+  },
+  "/services/upholstery-cleaning": {
+    title: "Upholstery Cleaning Services in Toronto | CleanAR Solutions",
+    description:
+      "Professional upholstery cleaning for sofas, chairs, and soft furniture across Toronto and the GTA.",
+  },
+  "/services/post-construction-cleaning": {
+    title: "Post-Construction Cleaning in Toronto | CleanAR Solutions",
+    description:
+      "Remove dust, debris, and construction residue with post-construction cleaning services in Toronto and the GTA.",
+  },
+  "/services/full-unit-clean-out": {
+    title: "Full Unit Clean-Out Services in Toronto | CleanAR Solutions",
+    description:
+      "Comprehensive full unit clean-out support for transitions and intensive reset projects in Toronto and the GTA.",
+  },
+  "/services/monthly-building-amenities-cleaning": {
+    title: "Monthly Building Amenities Cleaning in Toronto | CleanAR Solutions",
+    description:
+      "Recurring monthly cleaning for lobbies, amenities, and shared building spaces across Toronto and the GTA.",
   },
   "/services/carpet-and-upholstery-cleaning": {
     title: "Carpet & Upholstery Cleaning in Toronto | CleanAR Solutions",
@@ -204,6 +244,46 @@ export const MARKETING_PRERENDER_ROUTES = [
     h1: "Commercial Cleaning Services",
   },
   {
+    route: "/services/deep-cleaning",
+    output: "services/deep-cleaning/index.html",
+    h1: "Deep Cleaning Services",
+  },
+  {
+    route: "/services/move-in-move-out-cleaning",
+    output: "services/move-in-move-out-cleaning/index.html",
+    h1: "Move-In / Move-Out Cleaning Services",
+  },
+  {
+    route: "/services/commercial-deep-cleaning",
+    output: "services/commercial-deep-cleaning/index.html",
+    h1: "Commercial Deep Cleaning Services",
+  },
+  {
+    route: "/services/carpet-cleaning",
+    output: "services/carpet-cleaning/index.html",
+    h1: "Carpet Cleaning Services",
+  },
+  {
+    route: "/services/upholstery-cleaning",
+    output: "services/upholstery-cleaning/index.html",
+    h1: "Upholstery Cleaning Services",
+  },
+  {
+    route: "/services/post-construction-cleaning",
+    output: "services/post-construction-cleaning/index.html",
+    h1: "Post-Construction Cleaning Services",
+  },
+  {
+    route: "/services/full-unit-clean-out",
+    output: "services/full-unit-clean-out/index.html",
+    h1: "Full Unit Clean-Out Services",
+  },
+  {
+    route: "/services/monthly-building-amenities-cleaning",
+    output: "services/monthly-building-amenities-cleaning/index.html",
+    h1: "Monthly Building / Amenities Cleaning Services",
+  },
+  {
     route: "/services/window-cleaning",
     output: "services/window-cleaning/index.html",
     h1: "Window Cleaning Services",
@@ -233,6 +313,38 @@ const SERVICE_SCHEMA_CONFIG = {
   "/services/commercial-cleaning": {
     name: "Commercial Cleaning Services in Toronto & GTA",
     serviceType: "Commercial Cleaning",
+  },
+  "/services/deep-cleaning": {
+    name: "Deep Cleaning Services in Toronto & GTA",
+    serviceType: "Deep Cleaning",
+  },
+  "/services/move-in-move-out-cleaning": {
+    name: "Move-In and Move-Out Cleaning Services in Toronto & GTA",
+    serviceType: "Move-In Move-Out Cleaning",
+  },
+  "/services/commercial-deep-cleaning": {
+    name: "Commercial Deep Cleaning Services in Toronto & GTA",
+    serviceType: "Commercial Deep Cleaning",
+  },
+  "/services/carpet-cleaning": {
+    name: "Carpet Cleaning Services in Toronto & GTA",
+    serviceType: "Carpet Cleaning",
+  },
+  "/services/upholstery-cleaning": {
+    name: "Upholstery Cleaning Services in Toronto & GTA",
+    serviceType: "Upholstery Cleaning",
+  },
+  "/services/post-construction-cleaning": {
+    name: "Post-Construction Cleaning Services in Toronto & GTA",
+    serviceType: "Post-Construction Cleaning",
+  },
+  "/services/full-unit-clean-out": {
+    name: "Full Unit Clean-Out Services in Toronto & GTA",
+    serviceType: "Full Unit Clean-Out",
+  },
+  "/services/monthly-building-amenities-cleaning": {
+    name: "Monthly Building and Amenities Cleaning in Toronto & GTA",
+    serviceType: "Monthly Building Amenities Cleaning",
   },
   "/services/window-cleaning": {
     name: "Window Cleaning Services in Toronto & GTA",
@@ -282,6 +394,46 @@ const BREADCRUMB_CONFIG = {
     { name: "Home", path: "/" },
     { name: "Products and Services", path: "/products-and-services" },
     { name: "Commercial Cleaning", path: "/services/commercial-cleaning" },
+  ],
+  "/services/deep-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Deep Cleaning", path: "/services/deep-cleaning" },
+  ],
+  "/services/move-in-move-out-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Move-In / Move-Out Cleaning", path: "/services/move-in-move-out-cleaning" },
+  ],
+  "/services/commercial-deep-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Commercial Deep Cleaning", path: "/services/commercial-deep-cleaning" },
+  ],
+  "/services/carpet-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Carpet Cleaning", path: "/services/carpet-cleaning" },
+  ],
+  "/services/upholstery-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Upholstery Cleaning", path: "/services/upholstery-cleaning" },
+  ],
+  "/services/post-construction-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Post-Construction Cleaning", path: "/services/post-construction-cleaning" },
+  ],
+  "/services/full-unit-clean-out": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Full Unit Clean-Out", path: "/services/full-unit-clean-out" },
+  ],
+  "/services/monthly-building-amenities-cleaning": [
+    { name: "Home", path: "/" },
+    { name: "Products and Services", path: "/products-and-services" },
+    { name: "Monthly Building / Amenities Cleaning", path: "/services/monthly-building-amenities-cleaning" },
   ],
   "/services/window-cleaning": [
     { name: "Home", path: "/" },


### PR DESCRIPTION
### Motivation
- Align the Services hub with the new standardized service structure to improve conversions and make it easy for visitors to choose a service and request a quote.
- Keep existing CleanAR visual identity, routing, i18n, and React/Bootstrap architecture while avoiding new dependencies.
- Add a mobile-first, scannable layout (hero, category nav, core services, packages, add-ons, carpet & upholstery, specialty, how-it-works, final CTA) to reduce friction toward quote requests.
- Assumed the repo expects complete locale files, so English changes were mirrored to Spanish/French to avoid missing-key regressions.

### Description
- Replaced the `/products-and-services` component with a conversion-focused layout implemented in `client/src/components/Pages/Navigation/ProductsAndServices.jsx` and wired to the new `products_and_services.revamp` i18n keys.
- Appended page-scoped styles to the existing stylesheet `client/src/assets/css/our-palette.css` to implement trust chips, category chips (sticky on desktop), card treatments, compact lists, steps, and final CTA without introducing new CSS dependencies.
- Added comprehensive i18n content under `products_and_services.revamp` to `client/src/locales/en/translation.json` and mirrored the same block into `client/src/locales/es/translation.json` and `client/src/locales/fr/translation.json` to prevent missing-key UI issues.
- Updated SEO metadata for the Services route in `client/src/seo/routeMeta.mjs` to match the suggested title/description while preserving the existing `MetaTags`/helmet pattern and kept CTA links consistent with the existing quote flow using `/?service=...&scrollToQuote=true` and `/?scrollToQuote=true` anchors.

### Testing
- Built the frontend with `cd client && npm run build` and the build completed successfully and generated prerendered marketing routes (build output indicated success). 
- No new unit/integration tests were added; the change is validated by a successful production build and prerender step to avoid runtime missing-key or import errors.
- Verified that modified files compile and that localized keys exist for EN/ES/FR to prevent missing-key render issues in non-English modes.
- Manual visual QA outside this environment is recommended (check mobile-first layout, sticky category nav behaviour, and CTA scroll-to-quote routing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6afff5e48329b76e0b9ce10b3456)